### PR TITLE
Fixed issue #17

### DIFF
--- a/artifact/ast.txt
+++ b/artifact/ast.txt
@@ -1,5 +1,5 @@
 ========== AST ==========
-Program (Line 1, Col 0) with 4 declarations
+Program (Line 1, Col 0) with 3 declarations
  Declaration 1:
  VarDeclaration (Line 1, Col 0): x of type array of int with size IntegerLiteral (Line 1, Col 6): 3
 
@@ -7,35 +7,36 @@ Program (Line 1, Col 0) with 4 declarations
  FunctionDeclaration (Line 2, Col 0): main returns int with 1 parameters
    Parameter 1: arg of type int
    Body:
-   Block (Line 2, Col 18) with 1 items
+   Block (Line 2, Col 18) with 3 items
      Item 1:
      VarDeclaration (Line 3, Col 4): y of type int with initializer:
-       FunctionCallExpression (Line 3, Col 18) with 3 arguments:
+       FunctionCallExpression (Line 3, Col 18) with 2 arguments:
          Function:
          Identifier (Line 3, Col 12): addInt
          Argument 1:
            IntegerLiteral (Line 3, Col 19): 1
          Argument 2:
            IntegerLiteral (Line 3, Col 22): 2
-         Argument 3:
-           IntegerLiteral (Line 3, Col 25): 6
+     Item 2:
+     VarDeclaration (Line 4, Col 4): z of type char with initializer:
+       CharLiteral (Line 4, Col 13): 'c'
+     Item 3:
+     ReturnStatement (Line 5, Col 4):
+       ArrayAccessExpression (Line 5, Col 12):
+         Array:
+         Identifier (Line 5, Col 11): x
+         Index:
+         Identifier (Line 5, Col 13): z
  Declaration 3:
- FunctionDeclaration (Line 10, Col 4): foo returns void with 0 parameters
-   Body:
-   Block (Line 10, Col 15) with 1 items
-     Item 1:
-     ReturnStatement (Line 11, Col 8):
-       CharLiteral (Line 11, Col 15): 'c'
- Declaration 4:
- FunctionDeclaration (Line 14, Col 0): addInt returns int with 2 parameters
+ FunctionDeclaration (Line 8, Col 0): addInt returns int with 2 parameters
    Parameter 1: x of type int
    Parameter 2: y of type int
    Body:
-   Block (Line 14, Col 25) with 1 items
+   Block (Line 8, Col 25) with 1 items
      Item 1:
-     ReturnStatement (Line 15, Col 4):
-       BinaryExpression (Line 15, Col 13): Operator '+'
+     ReturnStatement (Line 9, Col 4):
+       BinaryExpression (Line 9, Col 13): Operator '+'
          Left:
-         Identifier (Line 15, Col 11): x
+         Identifier (Line 9, Col 11): x
          Right:
-         Identifier (Line 15, Col 15): yourMom
+         Identifier (Line 9, Col 15): y

--- a/artifact/ast.txt
+++ b/artifact/ast.txt
@@ -7,26 +7,17 @@ Program (Line 1, Col 0) with 3 declarations
  FunctionDeclaration (Line 2, Col 0): main returns int with 1 parameters
    Parameter 1: arg of type int
    Body:
-   Block (Line 2, Col 18) with 3 items
+   Block (Line 2, Col 18) with 2 items
      Item 1:
      VarDeclaration (Line 3, Col 4): y of type int with initializer:
-       FunctionCallExpression (Line 3, Col 18) with 2 arguments:
-         Function:
-         Identifier (Line 3, Col 12): addInt
-         Argument 1:
-           IntegerLiteral (Line 3, Col 19): 1
-         Argument 2:
-           IntegerLiteral (Line 3, Col 22): 2
+       IntegerLiteral (Line 3, Col 12): 2
      Item 2:
-     VarDeclaration (Line 4, Col 4): z of type char with initializer:
-       CharLiteral (Line 4, Col 13): 'c'
-     Item 3:
      ReturnStatement (Line 5, Col 4):
        ArrayAccessExpression (Line 5, Col 12):
          Array:
          Identifier (Line 5, Col 11): x
          Index:
-         Identifier (Line 5, Col 13): z
+         Identifier (Line 5, Col 13): y
  Declaration 3:
  FunctionDeclaration (Line 8, Col 0): addInt returns int with 2 parameters
    Parameter 1: x of type int

--- a/artifact/ast_tree.txt
+++ b/artifact/ast_tree.txt
@@ -1,25 +1,28 @@
 AST Tree:
-└── Program (Line 1, Col 0) with 4 declarations
+└── Program (Line 1, Col 0) with 3 declarations
     ├── VarDeclaration: x of type array of int with size 3
     ├── Function: main returns int with 1 parameters
     │   ├── Parameters:
     │   │   └── arg of type int
     │   └── Body:
-    │       └── Block with 1 items
-    │           └── VarDeclaration: y of type int
-    │               ├── Initializer:
-    │               │   └── FunctionCall with 3 arguments
-    │               │       ├── Function:
-    │               │       │   ├── Identifier: addInt
-    │               │       └── Arguments:
-    │               │           ├── IntegerLiteral: 1
-    │               │           ├── IntegerLiteral: 2
-    │               │           └── IntegerLiteral: 6
-    ├── Function: foo returns void with 0 parameters
-    │   └── Body:
-    │       └── Block with 1 items
+    │       └── Block with 3 items
+    │           ├── VarDeclaration: y of type int
+    │           │   ├── Initializer:
+    │           │   │   └── FunctionCall with 2 arguments
+    │           │   │       ├── Function:
+    │           │   │       │   ├── Identifier: addInt
+    │           │   │       └── Arguments:
+    │           │   │           ├── IntegerLiteral: 1
+    │           │   │           └── IntegerLiteral: 2
+    │           ├── VarDeclaration: z of type char
+    │           │   ├── Initializer:
+    │           │   │   └── CharLiteral: 'c'
     │           └── ReturnStatement
-    │               └── CharLiteral: 'c'
+    │               └── ArrayAccess
+    │                   ├── Array:
+    │                   │   ├── Identifier: x
+    │                   └── Index:
+    │                       └── Identifier: z
     └── Function: addInt returns int with 2 parameters
         ├── Parameters:
         │   ├── x of type int
@@ -31,4 +34,4 @@ AST Tree:
                         ├── Left:
                         │   ├── Identifier: x
                         └── Right:
-                            └── Identifier: yourMom
+                            └── Identifier: y

--- a/artifact/ast_tree.txt
+++ b/artifact/ast_tree.txt
@@ -5,24 +5,16 @@ AST Tree:
     │   ├── Parameters:
     │   │   └── arg of type int
     │   └── Body:
-    │       └── Block with 3 items
+    │       └── Block with 2 items
     │           ├── VarDeclaration: y of type int
     │           │   ├── Initializer:
-    │           │   │   └── FunctionCall with 2 arguments
-    │           │   │       ├── Function:
-    │           │   │       │   ├── Identifier: addInt
-    │           │   │       └── Arguments:
-    │           │   │           ├── IntegerLiteral: 1
-    │           │   │           └── IntegerLiteral: 2
-    │           ├── VarDeclaration: z of type char
-    │           │   ├── Initializer:
-    │           │   │   └── CharLiteral: 'c'
+    │           │   │   └── IntegerLiteral: 2
     │           └── ReturnStatement
     │               └── ArrayAccess
     │                   ├── Array:
     │                   │   ├── Identifier: x
     │                   └── Index:
-    │                       └── Identifier: z
+    │                       └── Identifier: y
     └── Function: addInt returns int with 2 parameters
         ├── Parameters:
         │   ├── x of type int

--- a/artifact/cst.txt
+++ b/artifact/cst.txt
@@ -88,35 +88,33 @@
 																														postfixExpression (
 																															primaryExpression (
 																																constant 2
-																															)))))))))))
-																					,
-																					(
-																						assignmentExpression (
-																							logicalOrExpression (
-																								logicalAndExpression (
-																									equalityExpression (
-																										comparisonExpression (
-																											additionExpression (
-																												multiplicationExpression (
-																													unaryExpression (
-																														postfixExpression (
-																															primaryExpression (
-																																constant 6
 																															))))))))))))
 																				)))))))))))))
 							;)))
-				})))
-	(
-		declaration (
-			type void
-		)
-		foo
-		(
-			declarationRemainder (
-				
-			)
-			(
-				block { (
+				(
+					blockItem (
+						declaration (
+							type char
+						)
+						z
+						(
+							declarationRemainder (
+								variableInitializer = (
+									expression (
+										assignmentExpression (
+											logicalOrExpression (
+												logicalAndExpression (
+													equalityExpression (
+														comparisonExpression (
+															additionExpression (
+																multiplicationExpression (
+																	unaryExpression (
+																		postfixExpression (
+																			primaryExpression (
+																				constant 'c'
+																			)))))))))))))
+							;)))
+				(
 					blockItem (
 						statement (
 							nonIfStatement (
@@ -131,9 +129,23 @@
 																multiplicationExpression (
 																	unaryExpression (
 																		postfixExpression (
-																			primaryExpression (
-																				constant 'c'
-																			))))))))))))
+																			primaryExpression x
+																		)
+																		(
+																			arrayAccess [ (
+																				expression (
+																					assignmentExpression (
+																						logicalOrExpression (
+																							logicalAndExpression (
+																								equalityExpression (
+																									comparisonExpression (
+																										additionExpression (
+																											multiplicationExpression (
+																												unaryExpression (
+																													postfixExpression (
+																														primaryExpression z
+																													)))))))))))
+																			])))))))))))
 								;))))
 				})))
 	(
@@ -182,7 +194,7 @@
 																	multiplicationExpression (
 																		unaryExpression (
 																			postfixExpression (
-																				primaryExpression yourMom
+																				primaryExpression y
 																			))))))))))))
 								;))))
 				})))

--- a/artifact/cst.txt
+++ b/artifact/cst.txt
@@ -57,61 +57,8 @@
 																multiplicationExpression (
 																	unaryExpression (
 																		postfixExpression (
-																			primaryExpression addInt
-																		)
-																		(
-																			functionCallArgs (
-																				(
-																					argList (
-																						assignmentExpression (
-																							logicalOrExpression (
-																								logicalAndExpression (
-																									equalityExpression (
-																										comparisonExpression (
-																											additionExpression (
-																												multiplicationExpression (
-																													unaryExpression (
-																														postfixExpression (
-																															primaryExpression (
-																																constant 1
-																															)))))))))))
-																					,
-																					(
-																						assignmentExpression (
-																							logicalOrExpression (
-																								logicalAndExpression (
-																									equalityExpression (
-																										comparisonExpression (
-																											additionExpression (
-																												multiplicationExpression (
-																													unaryExpression (
-																														postfixExpression (
-																															primaryExpression (
-																																constant 2
-																															))))))))))))
-																				)))))))))))))
-							;)))
-				(
-					blockItem (
-						declaration (
-							type char
-						)
-						z
-						(
-							declarationRemainder (
-								variableInitializer = (
-									expression (
-										assignmentExpression (
-											logicalOrExpression (
-												logicalAndExpression (
-													equalityExpression (
-														comparisonExpression (
-															additionExpression (
-																multiplicationExpression (
-																	unaryExpression (
-																		postfixExpression (
 																			primaryExpression (
-																				constant 'c'
+																				constant 2
 																			)))))))))))))
 							;)))
 				(
@@ -143,7 +90,7 @@
 																											multiplicationExpression (
 																												unaryExpression (
 																													postfixExpression (
-																														primaryExpression z
+																														primaryExpression y
 																													)))))))))))
 																			])))))))))))
 								;))))

--- a/artifact/cst_tree.txt
+++ b/artifact/cst_tree.txt
@@ -71,19 +71,6 @@ CST Tree:
     │           │           │                                                       │                                       └── constant
     │           │           │                                                       │                                           └── 1
     │           │           │                                                       ├── ,
-    │           │           │                                                       ├── assignmentExpression
-    │           │           │                                                       │   └── logicalOrExpression
-    │           │           │                                                       │       └── logicalAndExpression
-    │           │           │                                                       │           └── equalityExpression
-    │           │           │                                                       │               └── comparisonExpression
-    │           │           │                                                       │                   └── additionExpression
-    │           │           │                                                       │                       └── multiplicationExpression
-    │           │           │                                                       │                           └── unaryExpression
-    │           │           │                                                       │                               └── postfixExpression
-    │           │           │                                                       │                                   └── primaryExpression
-    │           │           │                                                       │                                       └── constant
-    │           │           │                                                       │                                           └── 2
-    │           │           │                                                       ├── ,
     │           │           │                                                       └── assignmentExpression
     │           │           │                                                           └── logicalOrExpression
     │           │           │                                                               └── logicalAndExpression
@@ -95,17 +82,30 @@ CST Tree:
     │           │           │                                                                                       └── postfixExpression
     │           │           │                                                                                           └── primaryExpression
     │           │           │                                                                                               └── constant
-    │           │           │                                                                                                   └── 6
+    │           │           │                                                                                                   └── 2
     │           │           └── ;
-    │           └── }
-    ├── declaration
-    │   ├── type
-    │   │   └── void
-    │   ├── foo
-    │   └── declarationRemainder
-    │       ├── 
-    │       └── block
-    │           ├── {
+    │           ├── blockItem
+    │           │   └── declaration
+    │           │       ├── type
+    │           │       │   └── char
+    │           │       ├── z
+    │           │       └── declarationRemainder
+    │           │           ├── variableInitializer
+    │           │           │   ├── =
+    │           │           │   └── expression
+    │           │           │       └── assignmentExpression
+    │           │           │           └── logicalOrExpression
+    │           │           │               └── logicalAndExpression
+    │           │           │                   └── equalityExpression
+    │           │           │                       └── comparisonExpression
+    │           │           │                           └── additionExpression
+    │           │           │                               └── multiplicationExpression
+    │           │           │                                   └── unaryExpression
+    │           │           │                                       └── postfixExpression
+    │           │           │                                           └── primaryExpression
+    │           │           │                                               └── constant
+    │           │           │                                                   └── 'c'
+    │           │           └── ;
     │           ├── blockItem
     │           │   └── statement
     │           │       └── nonIfStatement
@@ -121,9 +121,23 @@ CST Tree:
     │           │               │                           └── multiplicationExpression
     │           │               │                               └── unaryExpression
     │           │               │                                   └── postfixExpression
-    │           │               │                                       └── primaryExpression
-    │           │               │                                           └── constant
-    │           │               │                                               └── 'c'
+    │           │               │                                       ├── primaryExpression
+    │           │               │                                       │   └── x
+    │           │               │                                       └── arrayAccess
+    │           │               │                                           ├── [
+    │           │               │                                           ├── expression
+    │           │               │                                           │   └── assignmentExpression
+    │           │               │                                           │       └── logicalOrExpression
+    │           │               │                                           │           └── logicalAndExpression
+    │           │               │                                           │               └── equalityExpression
+    │           │               │                                           │                   └── comparisonExpression
+    │           │               │                                           │                       └── additionExpression
+    │           │               │                                           │                           └── multiplicationExpression
+    │           │               │                                           │                               └── unaryExpression
+    │           │               │                                           │                                   └── postfixExpression
+    │           │               │                                           │                                       └── primaryExpression
+    │           │               │                                           │                                           └── z
+    │           │               │                                           └── ]
     │           │               └── ;
     │           └── }
     ├── declaration
@@ -168,7 +182,7 @@ CST Tree:
     │           │               │                                   └── unaryExpression
     │           │               │                                       └── postfixExpression
     │           │               │                                           └── primaryExpression
-    │           │               │                                               └── yourMom
+    │           │               │                                               └── y
     │           │               └── ;
     │           └── }
     └── <EOF>

--- a/artifact/cst_tree.txt
+++ b/artifact/cst_tree.txt
@@ -53,58 +53,9 @@ CST Tree:
     │           │           │                               └── multiplicationExpression
     │           │           │                                   └── unaryExpression
     │           │           │                                       └── postfixExpression
-    │           │           │                                           ├── primaryExpression
-    │           │           │                                           │   └── addInt
-    │           │           │                                           └── functionCallArgs
-    │           │           │                                               └── 
-    │           │           │                                                   └── argList
-    │           │           │                                                       ├── assignmentExpression
-    │           │           │                                                       │   └── logicalOrExpression
-    │           │           │                                                       │       └── logicalAndExpression
-    │           │           │                                                       │           └── equalityExpression
-    │           │           │                                                       │               └── comparisonExpression
-    │           │           │                                                       │                   └── additionExpression
-    │           │           │                                                       │                       └── multiplicationExpression
-    │           │           │                                                       │                           └── unaryExpression
-    │           │           │                                                       │                               └── postfixExpression
-    │           │           │                                                       │                                   └── primaryExpression
-    │           │           │                                                       │                                       └── constant
-    │           │           │                                                       │                                           └── 1
-    │           │           │                                                       ├── ,
-    │           │           │                                                       └── assignmentExpression
-    │           │           │                                                           └── logicalOrExpression
-    │           │           │                                                               └── logicalAndExpression
-    │           │           │                                                                   └── equalityExpression
-    │           │           │                                                                       └── comparisonExpression
-    │           │           │                                                                           └── additionExpression
-    │           │           │                                                                               └── multiplicationExpression
-    │           │           │                                                                                   └── unaryExpression
-    │           │           │                                                                                       └── postfixExpression
-    │           │           │                                                                                           └── primaryExpression
-    │           │           │                                                                                               └── constant
-    │           │           │                                                                                                   └── 2
-    │           │           └── ;
-    │           ├── blockItem
-    │           │   └── declaration
-    │           │       ├── type
-    │           │       │   └── char
-    │           │       ├── z
-    │           │       └── declarationRemainder
-    │           │           ├── variableInitializer
-    │           │           │   ├── =
-    │           │           │   └── expression
-    │           │           │       └── assignmentExpression
-    │           │           │           └── logicalOrExpression
-    │           │           │               └── logicalAndExpression
-    │           │           │                   └── equalityExpression
-    │           │           │                       └── comparisonExpression
-    │           │           │                           └── additionExpression
-    │           │           │                               └── multiplicationExpression
-    │           │           │                                   └── unaryExpression
-    │           │           │                                       └── postfixExpression
     │           │           │                                           └── primaryExpression
     │           │           │                                               └── constant
-    │           │           │                                                   └── 'c'
+    │           │           │                                                   └── 2
     │           │           └── ;
     │           ├── blockItem
     │           │   └── statement
@@ -136,7 +87,7 @@ CST Tree:
     │           │               │                                           │                               └── unaryExpression
     │           │               │                                           │                                   └── postfixExpression
     │           │               │                                           │                                       └── primaryExpression
-    │           │               │                                           │                                           └── z
+    │           │               │                                           │                                           └── y
     │           │               │                                           └── ]
     │           │               └── ;
     │           └── }

--- a/pkg/semantic/semantic.go
+++ b/pkg/semantic/semantic.go
@@ -326,6 +326,15 @@ func (analyzer *SemanticAnalyzer) checkArrayAccessExpression(arrAcxessExpr *ast.
             if lit.Value < 0 || (size >= 0 && lit.Value >= size) {
                 analyzer.Error(arrAcxessExpr.Line, "index out of bounds")
             }
+        } else if variable, ok := arrAcxessExpr.Index.(*ast.Identifier); ok {
+            sym, ok := analyzer.SymTable.Lookup(variable.Name)
+            if !ok  {
+                analyzer.Error(arrAcxessExpr.Line, fmt.Sprintf("undefined symbol: %s", variable.Name))
+            } else if !isIntType(sym.Type) {
+                analyzer.Error(arrAcxessExpr.Line, fmt.Sprintf("index must be an integer literal or identifier, not %s", typeString(sym.Type)))
+            }
+        } else {
+            analyzer.Error(arrAcxessExpr.Line, "index must be an integer literal or identifier")
         }
         return arr.ElementType
     }

--- a/test/smol_sample.uia
+++ b/test/smol_sample.uia
@@ -1,8 +1,8 @@
 int x[3];
 int main(int arg) {
-    int y = addInt(1, 2);
-    char z = 'c';
-    return x[z];
+    int y = 2;
+    // char z = 'c';
+    return x[y];
 }
 
 int addInt(int x, int y) {

--- a/test/smol_sample.uia
+++ b/test/smol_sample.uia
@@ -1,16 +1,10 @@
 int x[3];
 int main(int arg) {
-    int y = addInt(1, 2, 6);
-    // if (y == 3) {
-    //     int z = 69;
-    // }
-    // return z;
-
+    int y = addInt(1, 2);
+    char z = 'c';
+    return x[z];
 }
-    void foo() {
-        return 'c';
-    }
 
 int addInt(int x, int y) {
-    return x + yourMom;
+    return x + y;
 }


### PR DESCRIPTION
Allow array access with variables, as well as recognized related errors:
- Using an undefined variable to access array
- Using a variable not of type `int` to access array