### PR TITLE
adding semantic error msg formatter and reconstruct folders

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,40 +1,51 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
+	"BigCooker/pkg/error_formatter"
 	"BigCooker/pkg/semantic"
 	"BigCooker/pkg/syntax"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 )
-       
+
 func main() {
-    if len(os.Args) < 2 {
-        fmt.Println("Please supply source file")
-        os.Exit(1)
-    }
-    
-    filename := os.Args[1]
-    // filename := "test/smol_sample.uia"
-    
-    program, err := syntax.ProcessFile(filename)
-    if err != nil {
-        fmt.Printf("Error processing file: %v\n", err)
-        os.Exit(1)
-    }
+	if len(os.Args) < 2 {
+		fmt.Println("Please supply source file")
+		os.Exit(1)
+	}
+	filename := os.Args[1]
 
-    
-    fmt.Println("Successfully processed file and generated artifacts.")
+	sourceBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Printf("Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+	sourceText := string(sourceBytes)
+	sourceLines := strings.Split(sourceText, "\n")
 
-    // Initialize the semantic analyzer
-    semanticAnalyzer := semantic.NewSemanticAnalyzer()
-    // Perform semantic analysis
-    if errs := semanticAnalyzer.Analyze(program); len(errs) > 0 {
-        for _, err := range errs {
-        fmt.Printf("Semantic analysis error: %v\n", err)
-        }
-    os.Exit(1)
-    }
-    fmt.Println("Semantic analysis completed successfully.")
+	program, err := syntax.ProcessFile(filename)
+	if err != nil {
+		fmt.Printf("Error processing file: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Successfully processed file and generated artifacts.")
+	fmt.Println("Syntax analysis completed successfully.")
 
+	// Initialize the semantic analyzer
+	semanticAnalyzer := semantic.NewSemanticAnalyzer()
+
+	// Perform semantic analysis
+	if errs := semanticAnalyzer.Analyze(program); len(errs) > 0 {
+		errorFormatter := error_formatter.NewSemanticErrorFormatter(sourceLines)
+		formattedErrors := errorFormatter.FormatErrors(errs)
+
+		for _, formattedErr := range formattedErrors {
+			fmt.Println(formattedErr)
+			fmt.Println()
+		}
+		os.Exit(1)
+	}
+	fmt.Println("Semantic analysis completed successfully.")
 }

--- a/pkg/error_formatter/semantic_error_formatter.go
+++ b/pkg/error_formatter/semantic_error_formatter.go
@@ -1,0 +1,192 @@
+package error_formatter
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Formats semantic errors in Rust style
+type SemanticErrorFormatter struct {
+	SourceLines []string
+}
+
+// Creates a new formatter with source lines
+func NewSemanticErrorFormatter(sourceLines []string) *SemanticErrorFormatter {
+	return &SemanticErrorFormatter{
+		SourceLines: sourceLines,
+	}
+}
+
+// Formats a single semantic error
+func (f *SemanticErrorFormatter) FormatError(rawError string) string {
+	// Extract line number and error message
+	parts := strings.SplitN(rawError, ": ", 2)
+	if len(parts) != 2 {
+		return rawError
+	}
+
+	var line int
+	_, err := fmt.Sscanf(parts[0], "Line %d", &line)
+	if err != nil {
+		return rawError
+	}
+
+	errorMsg := parts[1]
+	codeLine := ""
+	if line > 0 && line <= len(f.SourceLines) {
+		codeLine = f.SourceLines[line-1]
+	} else {
+		return rawError
+	}
+
+	column := findErrorPosition(codeLine, errorMsg)
+	caretLine := strings.Repeat(" ", column) + "^"
+	errorType := "Semantic Error"
+	detailedMsg := errorMsg
+
+	// Format the error message
+	fullMessage := fmt.Sprintf("line %d:%d\n%s\n%s\n%s: %s",
+		line, column, codeLine, caretLine, errorType, detailedMsg)
+
+	return fullMessage
+}
+
+// Formats all semantic errors
+func (f *SemanticErrorFormatter) FormatErrors(rawErrors []string) []string {
+	formatted := make([]string, len(rawErrors))
+	for i, rawError := range rawErrors {
+		formatted[i] = f.FormatError(rawError)
+	}
+	return formatted
+}
+
+func findErrorPosition(codeLine, errorMsg string) int {
+	// Specific error handling
+	if strings.Contains(errorMsg, "argument count mismatch") {
+		funcName := extractFunctionCall(errorMsg)
+		if funcName != "" {
+			callPos := strings.Index(codeLine, funcName+"(")
+			if callPos >= 0 {
+				return callPos + len(funcName)
+			}
+		}
+		parenPos := strings.Index(codeLine, "(")
+		if parenPos >= 0 {
+			return parenPos
+		}
+	}
+
+	if strings.Contains(errorMsg, "return type mismatch") {
+		retPos := strings.Index(codeLine, "return ")
+		if retPos >= 0 {
+			return retPos
+		}
+	}
+
+	if strings.Contains(errorMsg, "array access on non-array type") {
+		ids := extractIdentifiers(errorMsg)
+		for _, id := range ids {
+			bracketPos := strings.Index(codeLine, id+"[")
+			if bracketPos >= 0 {
+				return bracketPos + len(id)
+			}
+			idPos := strings.Index(codeLine, id)
+			if idPos >= 0 {
+				return idPos
+			}
+		}
+	}
+
+	// General identifier handling
+	identifiers := extractIdentifiers(errorMsg)
+	var targetIdentifier string
+	if strings.Contains(errorMsg, "undefined symbol: ") {
+		parts := strings.SplitN(errorMsg, "undefined symbol: ", 2)
+		if len(parts) > 1 {
+			targetIdentifier = strings.Fields(parts[1])[0]
+			targetIdentifier = strings.Trim(targetIdentifier, ".,():;'\"")
+		}
+	}
+
+	if targetIdentifier != "" {
+		pos := strings.Index(codeLine, targetIdentifier)
+		if pos >= 0 {
+			return pos
+		}
+	}
+
+	for _, id := range identifiers {
+		pos := strings.Index(codeLine, id)
+		if pos >= 0 {
+			return pos
+		}
+	}
+
+	// Operator handling
+	operators := []string{"==", "!=", "<=", ">=", "<", ">", "+", "-", "*", "/", "&&", "||", "!"}
+	for _, op := range operators {
+		if strings.Contains(errorMsg, fmt.Sprintf("operator '%s'", op)) || strings.Contains(errorMsg, op) {
+			pos := strings.Index(codeLine, op)
+			if pos >= 0 {
+				return pos
+			}
+		}
+	}
+
+	// Default to first non-whitespace character
+	for i, c := range codeLine {
+		if c != ' ' && c != '\t' {
+			return i
+		}
+	}
+
+	return 0
+}
+
+// Extracts function name from error message
+func extractFunctionCall(errorMsg string) string {
+	pattern := "function '"
+	if idx := strings.Index(errorMsg, pattern); idx != -1 {
+		start := idx + len(pattern)
+		end := strings.Index(errorMsg[start:], "'")
+		if end != -1 {
+			return errorMsg[start : start+end]
+		}
+	}
+	return ""
+}
+
+// Extracts identifiers from error message
+func extractIdentifiers(errorMsg string) []string {
+	identifiers := []string{}
+	patterns := []string{
+		"undefined symbol: ",
+		"variable ",
+		"function ",
+		"type mismatch: expected ",
+		", got ",
+		"array ",
+		"parameter ",
+		"type '",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(errorMsg, pattern) {
+			parts := strings.SplitN(errorMsg, pattern, 2)
+			if len(parts) > 1 {
+				word := strings.Split(parts[1], " ")[0]
+				word = strings.Split(word, "'")[0]
+				word = strings.Trim(word, ".,():;")
+				if word != "" && !isKeyword(word) {
+					identifiers = append(identifiers, word)
+				}
+			}
+		}
+	}
+	return identifiers
+}
+
+// Checks if a word is a keyword
+func isKeyword(word string) bool {
+	keywords := map[string]bool{"if": true, "else": true, "while": true, "return": true, "int": true, "bool": true}
+	return keywords[word]
+}

--- a/pkg/error_formatter/syntax_error_formatter.go
+++ b/pkg/error_formatter/syntax_error_formatter.go
@@ -1,4 +1,4 @@
-package parser
+package error_formatter
 
 import (
 	"fmt"

--- a/pkg/syntax/parser/parser.go
+++ b/pkg/syntax/parser/parser.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"BigCooker/pkg/error_formatter"
 	"BigCooker/pkg/syntax/ast"
 
 	"github.com/antlr4-go/antlr/v4"
@@ -27,7 +28,7 @@ func ParseFile(filename string) (*ast.Program, error) {
 	tokenStream := antlr.NewCommonTokenStream(lexer, 0)
 	p := NewBigCParser(tokenStream)
 
-	errorHandler := NewSyntaxErrorHandler(lines)
+	errorHandler := error_formatter.NewSyntaxErrorHandler(lines)
 	p.RemoveErrorListeners()
 	p.AddErrorListener(errorHandler)
 
@@ -55,137 +56,137 @@ type ASTBuilder struct {
 }
 
 func (v *ASTBuilder) Visit(tree antlr.ParseTree) interface{} {
-    // Direct dispatch based on node type
-	// if not override this Visit method, the antlr parsetree 
+	// Direct dispatch based on node type
+	// if not override this Visit method, the antlr parsetree
 	// waits for the method to be called (instead of dispatching)
-	// which returns all <nil> :) 
-    switch ctx := tree.(type) {
-    case *DeclarationContext:
-        return v.VisitDeclaration(ctx)
-    case *ProgramContext:
-        return v.VisitProgram(ctx)
-    case *ArrayNotationContext:
-        return v.VisitArrayNotation(ctx)
-    case *TypeContext:
-        return v.VisitType(ctx)
-    case *DeclarationRemainderContext:
-        return v.VisitDeclarationRemainder(ctx)
-    case *ParameterListContext:
-        return v.VisitParameterList(ctx)
-    case *ParameterContext:
-        return v.VisitParameter(ctx)
-    case *BlockContext:
-        return v.VisitBlock(ctx)
-    case *BlockItemContext:
-        return v.VisitBlockItem(ctx)
-    case *StatementContext:
-        return v.VisitStatement(ctx)
-    case *IfStatementContext:
-        return v.VisitIfStatement(ctx)
-    case *ElseClauseContext:
-        return v.VisitElseClause(ctx)
-    case *NonIfStatementContext:
-        return v.VisitNonIfStatement(ctx)
-    case *WhileStatementContext:
-        return v.VisitWhileStatement(ctx)
-    case *ReturnStatementContext:
-        return v.VisitReturnStatement(ctx)
-    case *ExpressionContext:
-        return v.VisitExpression(ctx)
-    case *AssignmentExpressionContext:
-        return v.VisitAssignmentExpression(ctx)
-    case *AssignmentRestContext:
-        return v.VisitAssignmentRest(ctx)
-    case *VariableInitializerContext:
-        return v.VisitVariableInitializer(ctx)
-    case *LogicalOrExpressionContext:
-        return v.VisitLogicalOrExpression(ctx)
-    case *LogicalOrRestContext:
-        return v.VisitLogicalOrRest(ctx)
-    case *LogicalAndExpressionContext:
-        return v.VisitLogicalAndExpression(ctx)
-    case *LogicalAndRestContext:
-        return v.VisitLogicalAndRest(ctx)
-    case *EqualityExpressionContext:
-        return v.VisitEqualityExpression(ctx)
-    case *EqualityRestContext:
-        return v.VisitEqualityRest(ctx)
-    case *EqualityOperatorContext:
-        return v.VisitEqualityOperator(ctx)
-    case *ComparisonExpressionContext:
-        return v.VisitComparisonExpression(ctx)
-    case *ComparisonRestContext:
-        return v.VisitComparisonRest(ctx)
-    case *ComparisonOperatorContext:
-        return v.VisitComparisonOperator(ctx)
-    case *AdditionExpressionContext:
-        return v.VisitAdditionExpression(ctx)
-    case *AdditionExpressionRestContext:
-        return v.VisitAdditionExpressionRest(ctx)
-    case *AddSubtractOperatorContext:
-        return v.VisitAddSubtractOperator(ctx)
-    case *MultiplicationExpressionContext:
-        return v.VisitMultiplicationExpression(ctx)
-    case *MultiplicationExpressionRestContext:
-        return v.VisitMultiplicationExpressionRest(ctx)
-    case *MultDivModOperatorContext:
-        return v.VisitMultDivModOperator(ctx)
-    case *UnaryExpressionContext:
-        return v.VisitUnaryExpression(ctx)
-    case *UnaryOperatorContext:
-        return v.VisitUnaryOperator(ctx)
-    case *PostfixExpressionContext:
-        return v.VisitPostfixExpression(ctx)
-    case *ArrayAccessContext:
-        return v.VisitArrayAccess(ctx)
-    case *FunctionCallArgsContext:
-        return v.VisitFunctionCallArgs(ctx)
-    case *ArgListContext:
-        return v.VisitArgList(ctx)
-    case *PrimaryExpressionContext:
-        return v.VisitPrimaryExpression(ctx)
-    case *ConstantContext:
-        return v.VisitConstant(ctx)
-    default:
-        fmt.Printf("WARNING: No specific visitor for type %T, using base visitor\n", tree)
-        result := v.BaseBigCVisitor.Visit(tree)
-        fmt.Printf("Base visitor returned: %v for %T\n", result, tree)
-        return result
-    }
+	// which returns all <nil> :)
+	switch ctx := tree.(type) {
+	case *DeclarationContext:
+		return v.VisitDeclaration(ctx)
+	case *ProgramContext:
+		return v.VisitProgram(ctx)
+	case *ArrayNotationContext:
+		return v.VisitArrayNotation(ctx)
+	case *TypeContext:
+		return v.VisitType(ctx)
+	case *DeclarationRemainderContext:
+		return v.VisitDeclarationRemainder(ctx)
+	case *ParameterListContext:
+		return v.VisitParameterList(ctx)
+	case *ParameterContext:
+		return v.VisitParameter(ctx)
+	case *BlockContext:
+		return v.VisitBlock(ctx)
+	case *BlockItemContext:
+		return v.VisitBlockItem(ctx)
+	case *StatementContext:
+		return v.VisitStatement(ctx)
+	case *IfStatementContext:
+		return v.VisitIfStatement(ctx)
+	case *ElseClauseContext:
+		return v.VisitElseClause(ctx)
+	case *NonIfStatementContext:
+		return v.VisitNonIfStatement(ctx)
+	case *WhileStatementContext:
+		return v.VisitWhileStatement(ctx)
+	case *ReturnStatementContext:
+		return v.VisitReturnStatement(ctx)
+	case *ExpressionContext:
+		return v.VisitExpression(ctx)
+	case *AssignmentExpressionContext:
+		return v.VisitAssignmentExpression(ctx)
+	case *AssignmentRestContext:
+		return v.VisitAssignmentRest(ctx)
+	case *VariableInitializerContext:
+		return v.VisitVariableInitializer(ctx)
+	case *LogicalOrExpressionContext:
+		return v.VisitLogicalOrExpression(ctx)
+	case *LogicalOrRestContext:
+		return v.VisitLogicalOrRest(ctx)
+	case *LogicalAndExpressionContext:
+		return v.VisitLogicalAndExpression(ctx)
+	case *LogicalAndRestContext:
+		return v.VisitLogicalAndRest(ctx)
+	case *EqualityExpressionContext:
+		return v.VisitEqualityExpression(ctx)
+	case *EqualityRestContext:
+		return v.VisitEqualityRest(ctx)
+	case *EqualityOperatorContext:
+		return v.VisitEqualityOperator(ctx)
+	case *ComparisonExpressionContext:
+		return v.VisitComparisonExpression(ctx)
+	case *ComparisonRestContext:
+		return v.VisitComparisonRest(ctx)
+	case *ComparisonOperatorContext:
+		return v.VisitComparisonOperator(ctx)
+	case *AdditionExpressionContext:
+		return v.VisitAdditionExpression(ctx)
+	case *AdditionExpressionRestContext:
+		return v.VisitAdditionExpressionRest(ctx)
+	case *AddSubtractOperatorContext:
+		return v.VisitAddSubtractOperator(ctx)
+	case *MultiplicationExpressionContext:
+		return v.VisitMultiplicationExpression(ctx)
+	case *MultiplicationExpressionRestContext:
+		return v.VisitMultiplicationExpressionRest(ctx)
+	case *MultDivModOperatorContext:
+		return v.VisitMultDivModOperator(ctx)
+	case *UnaryExpressionContext:
+		return v.VisitUnaryExpression(ctx)
+	case *UnaryOperatorContext:
+		return v.VisitUnaryOperator(ctx)
+	case *PostfixExpressionContext:
+		return v.VisitPostfixExpression(ctx)
+	case *ArrayAccessContext:
+		return v.VisitArrayAccess(ctx)
+	case *FunctionCallArgsContext:
+		return v.VisitFunctionCallArgs(ctx)
+	case *ArgListContext:
+		return v.VisitArgList(ctx)
+	case *PrimaryExpressionContext:
+		return v.VisitPrimaryExpression(ctx)
+	case *ConstantContext:
+		return v.VisitConstant(ctx)
+	default:
+		fmt.Printf("WARNING: No specific visitor for type %T, using base visitor\n", tree)
+		result := v.BaseBigCVisitor.Visit(tree)
+		fmt.Printf("Base visitor returned: %v for %T\n", result, tree)
+		return result
+	}
 }
 
 func NewASTBuilder() *ASTBuilder {
-    // [Important] gotta init this baby :) 
-    baseVisitor := &BaseBigCVisitor{
-        BaseParseTreeVisitor: &antlr.BaseParseTreeVisitor{},
-    }
-        
-    return &ASTBuilder{BaseBigCVisitor: baseVisitor}
+	// [Important] gotta init this baby :)
+	baseVisitor := &BaseBigCVisitor{
+		BaseParseTreeVisitor: &antlr.BaseParseTreeVisitor{},
+	}
+
+	return &ASTBuilder{BaseBigCVisitor: baseVisitor}
 }
 
 func (v *ASTBuilder) VisitProgram(ctx *ProgramContext) interface{} {
 	// set BaseNode properties
 	program := &ast.Program{
 		BaseNode: ast.BaseNode{
-			Line: 	    ctx.GetStart().GetLine(), 
-			Column:     ctx.GetStart().GetColumn(),
-            EndLine:    ctx.GetStop().GetLine(), 
-            EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			Line:      ctx.GetStart().GetLine(),
+			Column:    ctx.GetStart().GetColumn(),
+			EndLine:   ctx.GetStop().GetLine(),
+			EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
 		},
 	}
 
-	for i, declCtx := range ctx.AllDeclaration() {		
-		// visit 
+	for i, declCtx := range ctx.AllDeclaration() {
+		// visit
 		result := v.Visit(declCtx)
-		
+
 		if result == nil {
-			fmt.Printf("ERROR: Visit returned nil for declaration %d at Line %d: %s\n", 
+			fmt.Printf("ERROR: Visit returned nil for declaration %d at Line %d: %s\n",
 				i+1, declCtx.GetStart().GetLine(), declCtx.GetText())
 			continue
 		}
 		decl, ok := result.(ast.Declaration)
 		if !ok {
-			fmt.Printf("ERROR: Expected ast.Declaration but got %T for declaration %d at Line %d: %s\n", 
+			fmt.Printf("ERROR: Expected ast.Declaration but got %T for declaration %d at Line %d: %s\n",
 				result, i+1, declCtx.GetStart().GetLine(), declCtx.GetText())
 			continue
 		}
@@ -201,11 +202,11 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 
 	var typeNode ast.Type = &ast.PrimitiveType{
 		BaseType: ast.BaseType{
-			BaseNode: ast.BaseNode {
-				Line: 	ctx.GetStart().GetLine(),
-				Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			BaseNode: ast.BaseNode{
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
 			},
 		},
 		Name: typeName,
@@ -215,14 +216,14 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 	if arrayNotation != nil {
 		result := v.Visit(arrayNotation.Expression())
 		if result == nil {
-			fmt.Printf("ERROR: Array size expression returned nil at Line %d\n", 
+			fmt.Printf("ERROR: Array size expression returned nil at Line %d\n",
 				arrayNotation.GetStart().GetLine())
 			return nil
 		}
-		
+
 		sizeExpr, ok := result.(ast.Expression)
 		if !ok {
-			fmt.Printf("ERROR: Expected ast.Expression for array size but got %T at Line %d\n", 
+			fmt.Printf("ERROR: Expected ast.Expression for array size but got %T at Line %d\n",
 				result, arrayNotation.GetStart().GetLine())
 			return nil
 		}
@@ -230,45 +231,45 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 		typeNode = &ast.ArrayType{
 			BaseType: ast.BaseType{
 				BaseNode: ast.BaseNode{
-					Line:	arrayNotation.GetStart().GetLine(), 
-					Column: arrayNotation.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-				}, 
-			}, 
-			ElementType: typeNode, 
-			Size: 		 sizeExpr,
+					Line:      arrayNotation.GetStart().GetLine(),
+					Column:    arrayNotation.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			ElementType: typeNode,
+			Size:        sizeExpr,
 		}
 	}
 
 	declRemainder := ctx.DeclarationRemainder()
 	if declRemainder.GetChildCount() == 0 {
-		fmt.Printf("ERROR: DeclarationRemainder has no children at Line %d\n", 
+		fmt.Printf("ERROR: DeclarationRemainder has no children at Line %d\n",
 			declRemainder.GetStart().GetLine())
 		return nil
 	}
-	
+
 	firstChild := declRemainder.GetChild(0)
 	if firstChild == nil {
-		fmt.Printf("ERROR: First child of DeclarationRemainder is nil at Line %d\n", 
+		fmt.Printf("ERROR: First child of DeclarationRemainder is nil at Line %d\n",
 			declRemainder.GetStart().GetLine())
 		return nil
 	}
 
 	treeNode, ok := firstChild.(antlr.TerminalNode)
-	if ok && treeNode.GetText() == "(" {		
+	if ok && treeNode.GetText() == "(" {
 		// Case: function declaration
 		funcDecl := &ast.FunctionDeclaration{
 			BaseDeclaration: ast.BaseDeclaration{
 				BaseNode: ast.BaseNode{
-					Line: 	ctx.GetStart().GetLine(),
-					Column: ctx.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+					Line:      ctx.GetStart().GetLine(),
+					Column:    ctx.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
 				},
 			},
-			Name: 		identifier, 
-			ReturnType: typeNode, 
+			Name:       identifier,
+			ReturnType: typeNode,
 			Parameters: []ast.Parameter{},
 		}
 
@@ -277,43 +278,43 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 		if paramList != nil {
 			result := v.Visit(paramList)
 			if result == nil {
-				fmt.Printf("ERROR: ParameterList visit returned nil at Line %d\n", 
+				fmt.Printf("ERROR: ParameterList visit returned nil at Line %d\n",
 					paramList.GetStart().GetLine())
 				return nil
 			}
-			
+
 			params, ok := result.([]ast.Parameter)
 			if !ok {
-				fmt.Printf("ERROR: Expected []ast.Parameter but got %T at Line %d\n", 
+				fmt.Printf("ERROR: Expected []ast.Parameter but got %T at Line %d\n",
 					result, paramList.GetStart().GetLine())
 				return nil
 			}
-			
+
 			funcDecl.Parameters = params
 		}
 
 		// process function body
 		block := declRemainder.Block()
 		if block == nil {
-			fmt.Printf("ERROR: Function body (Block) is nil at Line %d\n", 
+			fmt.Printf("ERROR: Function body (Block) is nil at Line %d\n",
 				declRemainder.GetStart().GetLine())
 			return nil
 		}
-		
+
 		result := v.Visit(block)
 		if result == nil {
-			fmt.Printf("ERROR: Block visit returned nil at Line %d\n", 
+			fmt.Printf("ERROR: Block visit returned nil at Line %d\n",
 				block.GetStart().GetLine())
 			return nil
 		}
-		
+
 		body, ok := result.(*ast.Block)
 		if !ok {
-			fmt.Printf("ERROR: Expected *ast.Block but got %T at Line %d\n", 
+			fmt.Printf("ERROR: Expected *ast.Block but got %T at Line %d\n",
 				result, block.GetStart().GetLine())
 			return nil
 		}
-		
+
 		funcDecl.Body = body
 		return funcDecl
 	}
@@ -322,14 +323,14 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 	varDecl := &ast.VarDeclaration{
 		BaseDeclaration: ast.BaseDeclaration{
 			BaseNode: ast.BaseNode{
-				Line: 	ctx.GetStart().GetLine(),
-				Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
 			},
 		},
-		Name: 	identifier, 
-		Type: 	typeNode, 
+		Name: identifier,
+		Type: typeNode,
 	}
 
 	// initializer (if present)
@@ -337,25 +338,25 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 	if varInit != nil {
 		exprCtx := varInit.Expression()
 		if exprCtx == nil {
-			fmt.Printf("ERROR: Expression in VariableInitializer is nil at Line %d\n", 
+			fmt.Printf("ERROR: Expression in VariableInitializer is nil at Line %d\n",
 				varInit.GetStart().GetLine())
 			return nil
 		}
-		
+
 		result := v.Visit(exprCtx)
 		if result == nil {
-			fmt.Printf("ERROR: Expression visit returned nil at Line %d\n", 
+			fmt.Printf("ERROR: Expression visit returned nil at Line %d\n",
 				exprCtx.GetStart().GetLine())
 			return nil
 		}
-		
+
 		expr, ok := result.(ast.Expression)
 		if !ok {
-			fmt.Printf("ERROR: Expected ast.Expression but got %T at Line %d\n", 
+			fmt.Printf("ERROR: Expected ast.Expression but got %T at Line %d\n",
 				result, exprCtx.GetStart().GetLine())
 			return nil
 		}
-		
+
 		varDecl.Initializer = expr
 	}
 
@@ -363,176 +364,175 @@ func (v *ASTBuilder) VisitDeclaration(ctx *DeclarationContext) interface{} {
 }
 
 func (v *ASTBuilder) VisitParameter(ctx *ParameterContext) interface{} {
-    typeName := ctx.Type_().GetText()
+	typeName := ctx.Type_().GetText()
 	identifier := ctx.Identifier().GetText()
 
 	var typeNode ast.Type = &ast.PrimitiveType{
 		BaseType: ast.BaseType{
-			BaseNode: ast.BaseNode {
-				Line: 	ctx.GetStart().GetLine(),
-				Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			BaseNode: ast.BaseNode{
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
 			},
 		},
 		Name: typeName,
 	}
 
 	arrayNotation := ctx.ArrayNotation()
-	if (arrayNotation != nil) {
+	if arrayNotation != nil {
 		sizeExpr := v.Visit(arrayNotation.Expression()).(ast.Expression)
 
 		typeNode = &ast.ArrayType{
 			BaseType: ast.BaseType{
 				BaseNode: ast.BaseNode{
-					Line:	arrayNotation.GetStart().GetLine(), 
-					Column: arrayNotation.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-				}, 
-			}, 
-			ElementType: typeNode, 
-			Size: 		 sizeExpr,
+					Line:      arrayNotation.GetStart().GetLine(),
+					Column:    arrayNotation.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			ElementType: typeNode,
+			Size:        sizeExpr,
 		}
 	}
-    
-    return ast.Parameter{
-        BaseNode: ast.BaseNode{
-            Line:   ctx.GetStart().GetLine(),
-            Column: ctx.GetStart().GetColumn(),
-            EndLine:    ctx.GetStop().GetLine(), 
-            EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-        },
-        Name: identifier,
-        Type: typeNode,
-    }
+
+	return ast.Parameter{
+		BaseNode: ast.BaseNode{
+			Line:      ctx.GetStart().GetLine(),
+			Column:    ctx.GetStart().GetColumn(),
+			EndLine:   ctx.GetStop().GetLine(),
+			EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+		},
+		Name: identifier,
+		Type: typeNode,
+	}
 }
 
 func (v *ASTBuilder) VisitParameterList(ctx *ParameterListContext) interface{} {
-    var params []ast.Parameter
+	var params []ast.Parameter
 
-    for _, paramCtx := range ctx.AllParameter() {
-        param := v.Visit(paramCtx).(ast.Parameter)
-        params = append(params, param)
-    }
-    
-    return params
+	for _, paramCtx := range ctx.AllParameter() {
+		param := v.Visit(paramCtx).(ast.Parameter)
+		params = append(params, param)
+	}
+
+	return params
 }
 
 // ---------- Statements ----------
 func (v *ASTBuilder) VisitStatement(ctx *StatementContext) interface{} {
-    if ifStmt := ctx.IfStatement(); ifStmt != nil {
-        return v.Visit(ifStmt)
-    }
-    return v.Visit(ctx.NonIfStatement())
+	if ifStmt := ctx.IfStatement(); ifStmt != nil {
+		return v.Visit(ifStmt)
+	}
+	return v.Visit(ctx.NonIfStatement())
 }
 
 // If statements
 func (v *ASTBuilder) VisitIfStatement(ctx *IfStatementContext) interface{} {
-    ifStmt := &ast.IfStatement{
-        BaseStatement: ast.BaseStatement{
-            BaseNode: ast.BaseNode{
-                Line:   ctx.GetStart().GetLine(),
-                Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-            },
-        },
-        Condition: v.Visit(ctx.Expression()).(ast.Expression),
-        ThenBlock: v.Visit(ctx.Block()).(*ast.Block),
-    }
-    
-    elseClause := ctx.ElseClause()
-    if elseClause != nil {
-        if elseBlock := elseClause.Block(); elseBlock != nil {
-            ifStmt.ElseBlock = v.Visit(elseBlock).(ast.Node)
-        } else if elseIf := elseClause.IfStatement(); elseIf != nil {
-            ifStmt.ElseBlock = v.Visit(elseIf).(ast.Node)
-        }
-    }
-    
-    return ifStmt
+	ifStmt := &ast.IfStatement{
+		BaseStatement: ast.BaseStatement{
+			BaseNode: ast.BaseNode{
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			},
+		},
+		Condition: v.Visit(ctx.Expression()).(ast.Expression),
+		ThenBlock: v.Visit(ctx.Block()).(*ast.Block),
+	}
+
+	elseClause := ctx.ElseClause()
+	if elseClause != nil {
+		if elseBlock := elseClause.Block(); elseBlock != nil {
+			ifStmt.ElseBlock = v.Visit(elseBlock).(ast.Node)
+		} else if elseIf := elseClause.IfStatement(); elseIf != nil {
+			ifStmt.ElseBlock = v.Visit(elseIf).(ast.Node)
+		}
+	}
+
+	return ifStmt
 }
 
 // NonIfStatement (while, return)
 func (v *ASTBuilder) VisitNonIfStatement(ctx *NonIfStatementContext) interface{} {
-    if expr := ctx.Expression(); expr != nil {
-        return &ast.ExpressionStatement{
-            BaseStatement: ast.BaseStatement{
-                BaseNode: ast.BaseNode{
-                    Line:   expr.GetStart().GetLine(),
-                    Column: expr.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Expr: v.Visit(expr).(ast.Expression),
-        }
-    } else if whileStmt := ctx.WhileStatement(); whileStmt != nil {
-        return v.Visit(whileStmt)
-    } else if returnStmt := ctx.ReturnStatement(); returnStmt != nil {
-        return v.Visit(returnStmt)
-    }
-    
-    panic("Unknown non-if statement type")
+	if expr := ctx.Expression(); expr != nil {
+		return &ast.ExpressionStatement{
+			BaseStatement: ast.BaseStatement{
+				BaseNode: ast.BaseNode{
+					Line:      expr.GetStart().GetLine(),
+					Column:    expr.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Expr: v.Visit(expr).(ast.Expression),
+		}
+	} else if whileStmt := ctx.WhileStatement(); whileStmt != nil {
+		return v.Visit(whileStmt)
+	} else if returnStmt := ctx.ReturnStatement(); returnStmt != nil {
+		return v.Visit(returnStmt)
+	}
+
+	panic("Unknown non-if statement type")
 }
 
 func (v *ASTBuilder) VisitWhileStatement(ctx *WhileStatementContext) interface{} {
-    return &ast.WhileStatement{
-        BaseStatement: ast.BaseStatement{
-            BaseNode: ast.BaseNode{
-                Line:   ctx.GetStart().GetLine(),
-                Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-            },
-        },
-        Condition: v.Visit(ctx.Expression()).(ast.Expression),
-        Body:      v.Visit(ctx.Block()).(*ast.Block),
-    }
+	return &ast.WhileStatement{
+		BaseStatement: ast.BaseStatement{
+			BaseNode: ast.BaseNode{
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			},
+		},
+		Condition: v.Visit(ctx.Expression()).(ast.Expression),
+		Body:      v.Visit(ctx.Block()).(*ast.Block),
+	}
 }
 
 func (v *ASTBuilder) VisitReturnStatement(ctx *ReturnStatementContext) interface{} {
-    return &ast.ReturnStatement{
-        BaseStatement: ast.BaseStatement{
-            BaseNode: ast.BaseNode{
-                Line:   ctx.GetStart().GetLine(),
-                Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-            },
-        },
-        Value: v.Visit(ctx.Expression()).(ast.Expression),
-    }
+	return &ast.ReturnStatement{
+		BaseStatement: ast.BaseStatement{
+			BaseNode: ast.BaseNode{
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			},
+		},
+		Value: v.Visit(ctx.Expression()).(ast.Expression),
+	}
 }
 
-//
 func (v *ASTBuilder) VisitBlock(ctx *BlockContext) interface{} {
-    block := &ast.Block{
-        BaseStatement: ast.BaseStatement{
-            BaseNode: ast.BaseNode{
-                Line:   ctx.GetStart().GetLine(),
-                Column: ctx.GetStart().GetColumn(),
-                EndLine:    ctx.GetStop().GetLine(), 
-                EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-            },
-        },
-        Items: []ast.BlockItem{},
-    }
-    
-    for _, itemCtx := range ctx.AllBlockItem() {
-        item := v.Visit(itemCtx).(ast.BlockItem)
-        block.Items = append(block.Items, item)
-    }
-    
-    return block
+	block := &ast.Block{
+		BaseStatement: ast.BaseStatement{
+			BaseNode: ast.BaseNode{
+				Line:      ctx.GetStart().GetLine(),
+				Column:    ctx.GetStart().GetColumn(),
+				EndLine:   ctx.GetStop().GetLine(),
+				EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+			},
+		},
+		Items: []ast.BlockItem{},
+	}
+
+	for _, itemCtx := range ctx.AllBlockItem() {
+		item := v.Visit(itemCtx).(ast.BlockItem)
+		block.Items = append(block.Items, item)
+	}
+
+	return block
 }
 
 func (v *ASTBuilder) VisitBlockItem(ctx *BlockItemContext) interface{} {
-    if declCtx := ctx.Declaration(); declCtx != nil {
-        return v.Visit(declCtx)
-    }
-    return v.Visit(ctx.Statement())
+	if declCtx := ctx.Declaration(); declCtx != nil {
+		return v.Visit(declCtx)
+	}
+	return v.Visit(ctx.Statement())
 }
 
 // ---------- Expressions ----------
@@ -545,20 +545,20 @@ func (v *ASTBuilder) VisitAssignmentExpression(ctx *AssignmentExpressionContext)
 	expr := v.Visit(ctx.LogicalOrExpression()).(ast.Expression)
 
 	rest := ctx.AssignmentRest()
-	if (rest != nil) {
+	if rest != nil {
 		rightExpr := v.Visit(rest.AssignmentExpression()).(ast.Expression)
 		expr = &ast.BinaryExpression{
 			BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-			Left:		expr, 
-			Operator: 	"=",
-			Right: 		rightExpr, 
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: "=",
+			Right:    rightExpr,
 		}
 	}
 
@@ -572,19 +572,19 @@ func (v *ASTBuilder) VisitLogicalOrExpression(ctx *LogicalOrExpressionContext) i
 		rightExpr := v.Visit(rest.LogicalAndExpression()).(ast.Expression)
 		expr = &ast.BinaryExpression{
 			BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-			Left:		expr, 
-			Operator: 	"||",
-			Right: 		rightExpr, 
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: "||",
+			Right:    rightExpr,
 		}
 	}
-	
+
 	return expr
 }
 
@@ -595,19 +595,19 @@ func (v *ASTBuilder) VisitLogicalAndExpression(ctx *LogicalAndExpressionContext)
 		rightExpr := v.Visit(rest.EqualityExpression()).(ast.Expression)
 		expr = &ast.BinaryExpression{
 			BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-			Left:		expr, 
-			Operator: 	"&&",
-			Right: 		rightExpr, 
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: "&&",
+			Right:    rightExpr,
 		}
 	}
-	
+
 	return expr
 }
 
@@ -619,181 +619,180 @@ func (v *ASTBuilder) VisitEqualityExpression(ctx *EqualityExpressionContext) int
 		operator := rest.EqualityOperator().GetText()
 		expr = &ast.BinaryExpression{
 			BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-			Left:		expr, 
-			Operator: 	operator,
-			Right: 		rightExpr, 
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: operator,
+			Right:    rightExpr,
 		}
 	}
-	
+
 	return expr
 }
 
 func (v *ASTBuilder) VisitComparisonExpression(ctx *ComparisonExpressionContext) interface{} {
-    expr := v.Visit(ctx.AdditionExpression()).(ast.Expression)
-    
-    for _, rest := range ctx.AllComparisonRest() {
-        rightExpr := v.Visit(rest.AdditionExpression()).(ast.Expression)
-        operator := rest.ComparisonOperator().GetText()
-        expr = &ast.BinaryExpression{
-            BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Left:     expr,
-            Operator: operator,
-            Right:    rightExpr,
-        }
-    }
-    
-    return expr
+	expr := v.Visit(ctx.AdditionExpression()).(ast.Expression)
+
+	for _, rest := range ctx.AllComparisonRest() {
+		rightExpr := v.Visit(rest.AdditionExpression()).(ast.Expression)
+		operator := rest.ComparisonOperator().GetText()
+		expr = &ast.BinaryExpression{
+			BaseExpression: ast.BaseExpression{
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: operator,
+			Right:    rightExpr,
+		}
+	}
+
+	return expr
 }
 
 func (v *ASTBuilder) VisitAdditionExpression(ctx *AdditionExpressionContext) interface{} {
-    expr := v.Visit(ctx.MultiplicationExpression()).(ast.Expression)
-    
-    for _, rest := range ctx.AllAdditionExpressionRest() {
-        rightExpr := v.Visit(rest.MultiplicationExpression()).(ast.Expression)
-        operator := rest.AddSubtractOperator().GetText()
-        expr = &ast.BinaryExpression{
-            BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Left:     expr,
-            Operator: operator,
-            Right:    rightExpr,
-        }
-    }
-    
-    return expr
+	expr := v.Visit(ctx.MultiplicationExpression()).(ast.Expression)
+
+	for _, rest := range ctx.AllAdditionExpressionRest() {
+		rightExpr := v.Visit(rest.MultiplicationExpression()).(ast.Expression)
+		operator := rest.AddSubtractOperator().GetText()
+		expr = &ast.BinaryExpression{
+			BaseExpression: ast.BaseExpression{
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: operator,
+			Right:    rightExpr,
+		}
+	}
+
+	return expr
 }
 
 func (v *ASTBuilder) VisitMultiplicationExpression(ctx *MultiplicationExpressionContext) interface{} {
-    expr := v.Visit(ctx.UnaryExpression()).(ast.Expression)
-    
-    for _, rest := range ctx.AllMultiplicationExpressionRest() {
-        rightExpr := v.Visit(rest.UnaryExpression()).(ast.Expression)
-        operator := rest.MultDivModOperator().GetText()
-        expr = &ast.BinaryExpression{
-            BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   rest.GetStart().GetLine(),
-                    Column: rest.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Left:     expr,
-            Operator: operator,
-            Right:    rightExpr,
-        }
-    }
-    
-    return expr
+	expr := v.Visit(ctx.UnaryExpression()).(ast.Expression)
+
+	for _, rest := range ctx.AllMultiplicationExpressionRest() {
+		rightExpr := v.Visit(rest.UnaryExpression()).(ast.Expression)
+		operator := rest.MultDivModOperator().GetText()
+		expr = &ast.BinaryExpression{
+			BaseExpression: ast.BaseExpression{
+				BaseNode: ast.BaseNode{
+					Line:      rest.GetStart().GetLine(),
+					Column:    rest.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Left:     expr,
+			Operator: operator,
+			Right:    rightExpr,
+		}
+	}
+
+	return expr
 }
 
 func (v *ASTBuilder) VisitUnaryExpression(ctx *UnaryExpressionContext) interface{} {
-    opCtx := ctx.UnaryOperator()
-    if (opCtx != nil) {
-        operand := v.Visit(ctx.UnaryExpression()).(ast.Expression)
-        operator := opCtx.GetText()
-        
-        return &ast.UnaryExpression{
-            BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   opCtx.GetStart().GetLine(),
-                    Column: opCtx.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Operator: operator,
-            Operand:  operand,
-        }
-    }
-    
-    return v.Visit(ctx.PostfixExpression())
+	opCtx := ctx.UnaryOperator()
+	if opCtx != nil {
+		operand := v.Visit(ctx.UnaryExpression()).(ast.Expression)
+		operator := opCtx.GetText()
+
+		return &ast.UnaryExpression{
+			BaseExpression: ast.BaseExpression{
+				BaseNode: ast.BaseNode{
+					Line:      opCtx.GetStart().GetLine(),
+					Column:    opCtx.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Operator: operator,
+			Operand:  operand,
+		}
+	}
+
+	return v.Visit(ctx.PostfixExpression())
 }
 
 // (array access, function calls)
 func (v *ASTBuilder) VisitPostfixExpression(ctx *PostfixExpressionContext) interface{} {
-    primaryExpr := v.Visit(ctx.PrimaryExpression()).(ast.Expression)
+	primaryExpr := v.Visit(ctx.PrimaryExpression()).(ast.Expression)
 
-    arrAccess := ctx.ArrayAccess()
-    if (arrAccess != nil) {
-        indexExpr := v.Visit(arrAccess.Expression()).(ast.Expression)
-        return &ast.ArrayAccessExpression{
-            BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   arrAccess.GetStart().GetLine(),
-                    Column: arrAccess.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Array: primaryExpr,
-            Index: indexExpr,
-        }
-    }
-    
-    funcCall := ctx.FunctionCallArgs()
-    if funcCall != nil {
-        callExpr := &ast.FunctionCallExpression{
-            BaseExpression: ast.BaseExpression{
-                BaseNode: ast.BaseNode{
-                    Line:   funcCall.GetStart().GetLine(),
-                    Column: funcCall.GetStart().GetColumn(),
-                    EndLine:    ctx.GetStop().GetLine(), 
-                    EndColumn:  ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
-                },
-            },
-            Function:  primaryExpr,
-            Arguments: []ast.Expression{},
-        }
-        
-        // Process arguments if they exist
-        argList := funcCall.ArgList()
-        if argList != nil {
-            for _, argCtx := range argList.AllAssignmentExpression() {
-                argExpr := v.Visit(argCtx).(ast.Expression)
-                callExpr.Arguments = append(callExpr.Arguments, argExpr)
-            }
-        }
-        return callExpr
-    }
-    
-    return primaryExpr
+	arrAccess := ctx.ArrayAccess()
+	if arrAccess != nil {
+		indexExpr := v.Visit(arrAccess.Expression()).(ast.Expression)
+		return &ast.ArrayAccessExpression{
+			BaseExpression: ast.BaseExpression{
+				BaseNode: ast.BaseNode{
+					Line:      arrAccess.GetStart().GetLine(),
+					Column:    arrAccess.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Array: primaryExpr,
+			Index: indexExpr,
+		}
+	}
+
+	funcCall := ctx.FunctionCallArgs()
+	if funcCall != nil {
+		callExpr := &ast.FunctionCallExpression{
+			BaseExpression: ast.BaseExpression{
+				BaseNode: ast.BaseNode{
+					Line:      funcCall.GetStart().GetLine(),
+					Column:    funcCall.GetStart().GetColumn(),
+					EndLine:   ctx.GetStop().GetLine(),
+					EndColumn: ctx.GetStop().GetColumn() + len(ctx.GetStop().GetText()) - 1,
+				},
+			},
+			Function:  primaryExpr,
+			Arguments: []ast.Expression{},
+		}
+
+		// Process arguments if they exist
+		argList := funcCall.ArgList()
+		if argList != nil {
+			for _, argCtx := range argList.AllAssignmentExpression() {
+				argExpr := v.Visit(argCtx).(ast.Expression)
+				callExpr.Arguments = append(callExpr.Arguments, argExpr)
+			}
+		}
+		return callExpr
+	}
+
+	return primaryExpr
 }
 
-//
-func (v* ASTBuilder) VisitPrimaryExpression(ctx *PrimaryExpressionContext) interface{} {
+func (v *ASTBuilder) VisitPrimaryExpression(ctx *PrimaryExpressionContext) interface{} {
 	id := ctx.Identifier()
-	if (id != nil) {
+	if id != nil {
 		return v.plantIdentifier(id.GetSymbol())
 	}
-	
-	constant := ctx.Constant() 
-	if (constant != nil) {
+
+	constant := ctx.Constant()
+	if constant != nil {
 		return v.Visit(constant)
 	}
 
 	expr := ctx.Expression()
-	if (expr != nil) {
+	if expr != nil {
 		return v.Visit(expr)
 	}
 
@@ -801,27 +800,27 @@ func (v* ASTBuilder) VisitPrimaryExpression(ctx *PrimaryExpressionContext) inter
 }
 
 func (v *ASTBuilder) VisitConstant(ctx *ConstantContext) interface{} {
-    intConst := ctx.IntegerConstant()
-    if intConst != nil {
-        return v.plantIntegerLiteral(intConst.GetSymbol())
-    }
-    
-    floatConst := ctx.FloatingConstant()
-    if floatConst != nil {
-        return v.plantFloatLiteral(floatConst.GetSymbol())
-    }
-    
-    boolConst := ctx.BooleanConstant()
-    if boolConst != nil {
-        return v.plantBoolLiteral(boolConst.GetSymbol())
-    }
-    
-    charConst := ctx.CharConstant()
-    if charConst != nil {
-        return v.plantCharLiteral(charConst.GetSymbol())
-    }
-    
-    panic("Unknown constant type!!!")
+	intConst := ctx.IntegerConstant()
+	if intConst != nil {
+		return v.plantIntegerLiteral(intConst.GetSymbol())
+	}
+
+	floatConst := ctx.FloatingConstant()
+	if floatConst != nil {
+		return v.plantFloatLiteral(floatConst.GetSymbol())
+	}
+
+	boolConst := ctx.BooleanConstant()
+	if boolConst != nil {
+		return v.plantBoolLiteral(boolConst.GetSymbol())
+	}
+
+	charConst := ctx.CharConstant()
+	if charConst != nil {
+		return v.plantCharLiteral(charConst.GetSymbol())
+	}
+
+	panic("Unknown constant type!!!")
 }
 
 // ---------- Terminals Node ---------
@@ -831,12 +830,12 @@ func (v *ASTBuilder) plantIdentifier(token antlr.Token) *ast.Identifier {
 	return &ast.Identifier{
 		BaseExpression: ast.BaseExpression{
 			BaseNode: ast.BaseNode{
-				Line: 	    token.GetLine(), 
-				Column:     token.GetColumn(),
-                EndLine:    token.GetLine(), 
-                EndColumn:  token.GetColumn() + len(token.GetText()) - 1,
+				Line:      token.GetLine(),
+				Column:    token.GetColumn(),
+				EndLine:   token.GetLine(),
+				EndColumn: token.GetColumn() + len(token.GetText()) - 1,
 			},
-		}, 
+		},
 		Name: name,
 	}
 }
@@ -846,12 +845,12 @@ func (v *ASTBuilder) plantIntegerLiteral(token antlr.Token) *ast.IntegerLiteral 
 	return &ast.IntegerLiteral{
 		BaseExpression: ast.BaseExpression{
 			BaseNode: ast.BaseNode{
-				Line: 	    token.GetLine(), 
-				Column:     token.GetColumn(),
-                EndLine:    token.GetLine(), 
-                EndColumn:  token.GetColumn() + len(token.GetText()) - 1,
+				Line:      token.GetLine(),
+				Column:    token.GetColumn(),
+				EndLine:   token.GetLine(),
+				EndColumn: token.GetColumn() + len(token.GetText()) - 1,
 			},
-		}, 
+		},
 		Value: value,
 	}
 }
@@ -862,12 +861,12 @@ func (v *ASTBuilder) plantFloatLiteral(token antlr.Token) *ast.FloatLiteral {
 	return &ast.FloatLiteral{
 		BaseExpression: ast.BaseExpression{
 			BaseNode: ast.BaseNode{
-				Line: 	    token.GetLine(), 
-				Column:     token.GetColumn(),
-                EndLine:    token.GetLine(), 
-                EndColumn:  token.GetColumn() + len(token.GetText()) - 1,
+				Line:      token.GetLine(),
+				Column:    token.GetColumn(),
+				EndLine:   token.GetLine(),
+				EndColumn: token.GetColumn() + len(token.GetText()) - 1,
 			},
-		}, 
+		},
 		Value: value,
 	}
 }
@@ -878,12 +877,12 @@ func (v *ASTBuilder) plantBoolLiteral(token antlr.Token) *ast.BoolLiteral {
 	return &ast.BoolLiteral{
 		BaseExpression: ast.BaseExpression{
 			BaseNode: ast.BaseNode{
-				Line: 	    token.GetLine(), 
-				Column:     token.GetColumn(),
-                EndLine:    token.GetLine(), 
-                EndColumn:  token.GetColumn() + len(token.GetText()) - 1,
+				Line:      token.GetLine(),
+				Column:    token.GetColumn(),
+				EndLine:   token.GetLine(),
+				EndColumn: token.GetColumn() + len(token.GetText()) - 1,
 			},
-		}, 
+		},
 		Value: value,
 	}
 }
@@ -892,38 +891,38 @@ func (v *ASTBuilder) plantCharLiteral(token antlr.Token) *ast.CharLiteral {
 	text := token.GetText()
 	text = text[1 : len(text)-1] // extract quotes
 
-	var value rune 
-	if (len(text) == 1){
+	var value rune
+	if len(text) == 1 {
 		value = rune(text[0])
 	} else if text[0] == '\\' {
 		// escape character
-		switch text[1]{
+		switch text[1] {
 		case 'n':
 			value = '\n'
 		case 't':
-            value = '\t'
-        case 'r':
-            value = '\r'
-        case '\\':
-            value = '\\'
-        case '\'':
-            value = '\''
-        case '0':
-            value = 0
-        default:
-            value = rune(text[1])
+			value = '\t'
+		case 'r':
+			value = '\r'
+		case '\\':
+			value = '\\'
+		case '\'':
+			value = '\''
+		case '0':
+			value = 0
+		default:
+			value = rune(text[1])
 		}
 	}
 
 	return &ast.CharLiteral{
 		BaseExpression: ast.BaseExpression{
 			BaseNode: ast.BaseNode{
-				Line: 	    token.GetLine(), 
-				Column:     token.GetColumn(),
-                EndLine:    token.GetLine(), 
-                EndColumn:  token.GetColumn() + len(token.GetText()) - 1,
+				Line:      token.GetLine(),
+				Column:    token.GetColumn(),
+				EndLine:   token.GetLine(),
+				EndColumn: token.GetColumn() + len(token.GetText()) - 1,
 			},
-		}, 
+		},
 		Value: value,
 	}
 }

--- a/test/sematic_errors.uia
+++ b/test/sematic_errors.uia
@@ -1,0 +1,50 @@
+// === Test 1: Index out of bound ===
+void main() {
+    int arr[3];
+    int x = arr[5];
+}
+
+// === Test 2: Divide by zero ===
+void main() {
+    int x = 10 / 0;
+}
+
+// === Test 3: Assignment type mismatch ===
+void main() {
+    int x = true;
+}
+
+// === Test 4: Function return type mismatch ===
+int getNumber() {
+    return true;
+}
+
+// === Test 5: Operator type mismatch ===
+void main() {
+    int x = 5 + false;
+}
+
+// === Test 6: Function argument type mismatch ===
+void printNumber(int x) {}
+void main() {
+    printNumber("hello");
+}
+
+// === Test 7: Argument count mismatch ===
+void add(int a, int b) {}
+void main() {
+    add(10);
+}
+
+// === Test 8: Undefined symbol ===
+void main() {
+    int y = x + 1;
+}
+
+// === Test 9: Variable out of scope ===
+void main() {
+    if (true) {
+        int x = 5;
+    }
+    int y = x + 1;
+}


### PR DESCRIPTION
- Separate formatters for syntax and semantic errors, as combining them into a single function is non-trivial — syntax is handled by ANTLR, while semantic errors are managed by Mr. Sid

- Since main.go already enforces the correct compile order (syntax → semantic), no need for a unified formatting manager.

- Added a semantic error formatter: reuses existing messages from semantic.go, adds line context and pointer "^" to indicate error position.

- Refactored folder structure: moved both syntax and semantic formatters into a package for better organization.

- Adding a testing file for semantic error formatter.