### PR TITLE
Add function to insert new labels into .data section after it has been written

### DIFF
--- a/pkg/codegen/README.md
+++ b/pkg/codegen/README.md
@@ -1,7 +1,17 @@
-- all assembly code written to `asm.asm` 
-- order of things 
-    - expression (incl. array) -- Sid
-    - assignment (incl. array) -- Khoa
-    - branch                   -- LP
-    - function          -- together
-    - loop              -- together 
+- all assembly code written to `asm.asm`
+- order of things
+  - expression (incl. array) -- Sid
+    - [ ] Primary expressions (constants, variables, parenthesized)
+    - [ ] Postfix operations (arr[i], fn(), x++, x--) -- only support the first 2
+    - [ ] Unary operations (!x, ++x, --x) -- only support the first
+    - [ ] Multiplicative (\*, /)
+    - [ ] Additive (+, -)
+    - [ ] Comparison (<, <=, >=, >)
+    - [ ] Equality (==, !=)
+    - [ ] Logical AND (&&)
+    - [ ] Logical OR (||)
+    - [ ] Assignment (=)
+  - assignment (incl. array) -- Khoa
+  - branch -- LP
+  - function -- together
+  - loop -- together

--- a/pkg/codegen/README.md
+++ b/pkg/codegen/README.md
@@ -1,0 +1,7 @@
+- all assembly code written to `asm.asm` 
+- order of things 
+    - expression (incl. array) -- Sid
+    - assignment (incl. array) -- Khoa
+    - branch                   -- LP
+    - function          -- together
+    - loop              -- together 

--- a/pkg/codegen/asm_snippets/add_1_imm.asm
+++ b/pkg/codegen/asm_snippets/add_1_imm.asm
@@ -2,7 +2,7 @@
 x: .word 8000 # Store the larger value inside the word
 .text
 main:
-# If at least 1 value is in immediate range [-2048, 2047]
+# If at 1 value is in immediate range [-2048, 2047]
     la t0, x     
     lw t0, 0(t0) # t0 = 200 
     addi t1, t0, 10   # t1 = t0 + 10

--- a/pkg/codegen/asm_snippets/add_2_imm.asm
+++ b/pkg/codegen/asm_snippets/add_2_imm.asm
@@ -1,0 +1,10 @@
+.text
+main:
+# If both values are in immediate range [-2048, 2047]
+    li t0, 100     
+    addi t1, t0, 11   # t1 = t0 + 11
+
+# Print result
+    li a7, 1
+    mv a0, t1
+    ecall

--- a/pkg/codegen/asm_snippets/add_imm.asm
+++ b/pkg/codegen/asm_snippets/add_imm.asm
@@ -1,0 +1,13 @@
+.data
+x: .word 8000 # Store the larger value inside the word
+.text
+main:
+# If at least 1 value is in immediate range [-2048, 2047]
+    la t0, x     
+    lw t0, 0(t0) # t0 = 200 
+    addi t1, t0, 10   # t1 = t0 + 10
+
+# Print result
+    li a7, 1
+    mv a0, t1
+    ecall

--- a/pkg/codegen/asm_snippets/add_not_imm.asm
+++ b/pkg/codegen/asm_snippets/add_not_imm.asm
@@ -1,0 +1,16 @@
+.data
+x: .word 10
+y: .word 8000
+.text
+main:
+# If not immediate (in range [-2048, 2047]
+    la t0, x      # t0 = address(x)
+    lw t0, 0(t0)	# t0 = x
+    la t1, y      # t1 = address(y)
+    lw t1, 0(t1)	# t1 = y
+    add t1, t1, t0   # t1 = t0 + 200
+
+# Print result
+    li a7, 1
+    mv a0, t1
+    ecall

--- a/pkg/codegen/asm_snippets/sub_1_imm.asm
+++ b/pkg/codegen/asm_snippets/sub_1_imm.asm
@@ -1,0 +1,14 @@
+.data
+x: .word 8000 # Store the larger value inside the word
+.text
+main:
+# If at 1 value is in immediate range [-2048, 2047]
+    la t0, x     
+    lw t0, 0(t0) # t0 = 200 
+    li t1, 10   # Load immediate value 10 into t1
+    sub t1, t1, t0   # t1 = t0 + 10
+
+# Print result
+    li a7, 1
+    mv a0, t1
+    ecall

--- a/pkg/codegen/asm_snippets/sub_2_imm.asm
+++ b/pkg/codegen/asm_snippets/sub_2_imm.asm
@@ -1,0 +1,11 @@
+.text
+main:
+# If both values are in immediate range [-2048, 2047]
+    li t0, 100     
+    li t1, 201
+    sub t1, t1, t0   # t1 = t1 - t0
+
+# Print result
+    li a7, 1
+    mv a0, t1
+    ecall

--- a/pkg/codegen/asm_snippets/sub_not_imm.asm
+++ b/pkg/codegen/asm_snippets/sub_not_imm.asm
@@ -1,0 +1,16 @@
+.data
+x: .word 10
+y: .word 8000
+.text
+main:
+# If not immediate (in range [-2048, 2047]
+    la t0, x      # t0 = address(x)
+    lw t0, 0(t0)	# t0 = x
+    la t1, y      # t1 = address(y)
+    lw t1, 0(t1)	# t1 = y
+    sub t1, t1, t0   # t1 = t0 + 200
+
+# Print result
+    li a7, 1
+    mv a0, t1
+    ecall

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1,0 +1,35 @@
+package codegen 
+
+import (
+    "strings"
+    "BigCooker/pkg/semantic/table"
+    "BigCooker/pkg/syntax/ast"
+)
+
+type CodeGenerator struct {
+    Program     *ast.Program        // ast root
+    SymTable    *table.SymbolTable  // symbol table
+    AsmOut      *strings.Builder    // assembly string output
+
+    // program state tracking 
+    CurrentFunction string 
+    Labels          int
+    Registers       *RegisterPool
+    StackSize       int
+    VarStackOffset  map[string]int
+
+    //
+    ExpressionGen   *ExpressionGenerator 
+    AssignmentGen   *AssignmentGenerator
+    BranchingGen    *BranchingGenerator
+    FunctionGen     *FunctionGenerator
+    LoopingGen      *LoopingGenerator
+}
+
+type RegisterPool struct {
+    TmpRegs     []string
+    ArgRegs     []string
+    SavedRegs   []string
+    SpecialRegs []string
+    InUse       map[string] bool
+}

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -6,6 +6,95 @@ import (
     "BigCooker/pkg/syntax/ast"
 )
 
+type RegisterPool struct {
+    TmpRegs     []string // t0-t6
+    ArgRegs     []string // a0-a7
+    SavedRegs   []string // s1-s11
+    Reserved    []string // zero, ra, sp, gp, tp, s0/fp
+
+    InUse       map[string]bool
+}
+
+func NewRegisterPool() *RegisterPool {
+    tmps := []string{"t0", "t1", "t2", "t3", "t4", "t5", "t6"}
+    args := []string{"a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7"}
+    saves := []string{"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11"}
+    rsv := []string{"zero", "ra", "sp", "gp", "tp", "s0", "fp"}
+
+    return &RegisterPool{
+        TmpRegs:    tmps, 
+        ArgRegs:    args, 
+        SavedRegs:  saves, 
+        Reserved:   rsv,
+        InUse:      make(map[string]bool),
+    }
+}
+
+/*
+// Closer to a standard allocate register function 
+// But seemingly too advanced for our usecase 
+// For now, just use GetXRegister() to allocate 
+// register from a specific type (temp, arg, saved, etc.)
+// I keep this here for future references 
+
+func (rp *RegisterPool) GetRegister(preferCalleeSaved bool) string {
+    primaryPool := rp.TmpRegs
+    secondaryPool := rp.ArgRegs
+    tertiaryPool := rp.SavedRegs
+
+    if preferCalleeSaved { // if need registers that span between functions
+        primaryPool := rp.SavedRegs
+        secondaryPool := rp.TmpRegs
+        tertiaryPool := rp.ArgRegs
+    }
+    // ...
+}
+*/
+
+func (rp *RegisterPool) GetTmpRegister() string {
+    return rp.AllocateRegisterFallback([][]string{
+        rp.TmpRegs,
+        rp.ArgRegs[2:], 
+        rp.ArgRegs[:2], // a0-a1 usually for return value, try to not use them
+        rp.SavedRegs,   // last resort
+    })
+}
+
+func (rp *RegisterPool) GetArgRegister(index int) string {
+    if index >=0 && index < len(rp.ArgRegs) {
+        reg := rp.ArgRegs[index]
+        if !rp.InUse[reg]{
+            rp.InUse[reg] = true 
+            return reg
+        }
+    }
+
+    return rp.GetTmpRegister()
+}
+
+func (rp *RegisterPool) GetSavedRegister() string {
+    return rp.AllocateRegisterFallback([][]string{
+        rp.SavedRegs, 
+        rp.TmpRegs, 
+        rp.ArgRegs[2:], 
+        rp.ArgRegs[:2], 
+    })
+}
+
+func (rp *RegisterPool) AllocateRegisterFallback(regGroups [][]string) string {
+    for _, group := range regGroups {
+        for _, reg := range group {
+            if !rp.InUse[reg] && !contains(rp.Reserved, reg){
+                rp.InUse[reg] = true 
+                return reg 
+            }
+        }
+    }
+
+    panic("No register available. Don't know what do.")
+}
+
+
 type CodeGenerator struct {
     Program     *ast.Program        // ast root
     SymTable    *table.SymbolTable  // symbol table
@@ -26,10 +115,20 @@ type CodeGenerator struct {
     LoopingGen      *LoopingGenerator
 }
 
-type RegisterPool struct {
-    TmpRegs     []string
-    ArgRegs     []string
-    SavedRegs   []string
-    SpecialRegs []string
-    InUse       map[string] bool
+func NewCodeGenerator(program *ast.Program, symTable *table.SymbolTable) *CodeGenerator {
+    cg := &CodeGenerator{
+        Program:        program, 
+        SymTable:       symTable, 
+        Labels:         0, 
+        Registers:      NewRegisterPool(), 
+        VarStackOffset: make(map[string]int)
+    }
+
+    cg.ExpressionGen = NewExpressionGenerator(cg)
+    cg.AssignmentGen = NewAssignmentGenerator(cg)
+	cg.BranchingGen  = NewBranchingGenerator(cg)
+	cg.FunctionGen   = NewFunctionGenerator(cg)
+	cg.LoopingGen    = NewLoopingGenerator(cg)
+
+    return cg
 }

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash 
 
 if [ -n $SOURCE_FILE ]; then
-    SOURCE_FILE='test/semantic_tests.uia'
+    SOURCE_FILE='test/smol_sample.uia'
 else 
     SOURCE_FILE="$1"
 fi 


### PR DESCRIPTION
The .data section will most likely be written first while analyzing all the declarations, so insertData will let you insert new labels into the .data section after it has been written. For now, I need it for expressions regarding floating point numbers. I believe we will all need it later.

Example:
```
.data
x: .word 1 # random
.text
main:
# Print
    la t0, x
    lw t1, 0(t0) # t1 = x
    li a7, 1
    mv a0, t1
    ecall
```

Then we need to add a floating point addition. Thus we will need 2 more labels in the .data section. insertData allows you to do this
```
x: .word 1 # random
# This must be added afterwards
a: .double 6.9  
b: .double 4.2
.text
main:
# Print
    la t0, x
    lw t1, 0(t0) # t1 = x
    li a7, 1
    mv a0, t1
    ecall
# Start of floating addition
    la t0, a     
    fld ft0, 0(t0) # t0 = a
    
    la t1, b     
    fld ft1, 0(t1) # t1 = b
    
    fadd.d ft1, ft1, ft0   # t1 = t1 + t0

# Print result
    li a7, 3
    fmv.d fa0, ft1
    ecall
```

