### PR TITLE
Fix #33: Floating point expressions

### DIFF
--- a/pkg/codegen/assignment_gen.go
+++ b/pkg/codegen/assignment_gen.go
@@ -47,7 +47,7 @@ func (ag *AssignmentGenerator) GenerateVarDeclaration(varDeclr ast.VarDeclaratio
 
 		if offset, exists := cg.VarStackOffset[varDeclr.Name]; exists {
 			if isFloatType(varDeclr.Type) {
-				cg.emit("	fs %s, %d(sp)", resultRegister, offset)
+				cg.emit("	fsd %s, %d(sp)", resultRegister, offset)
 			} else {
 				cg.emit("	sd %s, %d(sp)", resultRegister, offset)
 			}

--- a/pkg/codegen/expression_gen.go
+++ b/pkg/codegen/expression_gen.go
@@ -180,12 +180,12 @@ func (eg *ExpressionGenerator) GenerateFunctionCallExpression(expr *ast.Function
 			if isFloatParam {
                 // float parameter should be in faN
                 if argRegister != fmt.Sprintf("fa%d", i) {
-                    cg.emit("    fmv.d fa%d, %s", i, argRegister)
+                    cg.emit("	fmv.d fa%d, %s", i, argRegister)
                 }
             } else {
                 // non float parameter should be in aN
                 if argRegister != fmt.Sprintf("a%d", i) {
-                    cg.emit("    mv a%d, %s", i, argRegister)
+                    cg.emit("	mv a%d, %s", i, argRegister)
                 }
             }
 		} else {
@@ -357,9 +357,9 @@ func (eg *ExpressionGenerator) GenerateIntDivision(leftInt int64, rightInt int64
 	leftReg := rp.GetTmpRegister()
 	rightReg := rp.GetTmpRegister()
 
-	cg.emit("li %s, %d", leftReg, leftInt)
-	cg.emit("li %s, %d", rightReg, rightInt)
-	cg.emit("div a0, %s, %s", leftReg, rightReg)
+	cg.emit("	li %s, %d", leftReg, leftInt)
+	cg.emit("	li %s, %d", rightReg, rightInt)
+	cg.emit("	div a0, %s, %s", leftReg, rightReg)
 	// The result will be a 128 bit integer, but for now we will just return the lower 64 bits
 	// Meaning we will ignore overflow, very C-like
 
@@ -373,17 +373,19 @@ func (eg *ExpressionGenerator) GenerateFloatDivision(leftFloat float64, rightFlo
 	cg.insertData("double_1", ".double", leftFloat)
 	cg.insertData("double_2", ".double", rightFloat)
 
+	leftAddressReg := rp.GetTmpRegister()
+	rightAddressReg := rp.GetTmpRegister()
 	// Load float values into registers
 	leftReg := rp.GetFloatTmpRegister()
 	rightReg := rp.GetFloatTmpRegister()
 	// Load left float value
-	cg.emit("la %s, double_1", leftReg)
-	cg.emit("fld %s, 0(%s)", leftReg, leftReg)
+	cg.emit("	la %s, double_1", leftAddressReg)
+	cg.emit("	fld %s, 0(%s)", leftReg, leftAddressReg)
 	// Load right float value
-	cg.emit("la %s, double_2", rightReg)
-	cg.emit("fld %s, 0(%s)", rightReg, rightReg)
+	cg.emit("	la %s, double_2", rightAddressReg)
+	cg.emit("	fld %s, 0(%s)", rightReg, rightAddressReg)
 	// Perform subtraction
-	cg.emit("fdiv.d fa0, %s, %s", leftReg, rightReg)
+	cg.emit("	fdiv.d fa0, %s, %s", leftReg, rightReg)
 
 	return "fa0"
 }
@@ -431,9 +433,9 @@ func (eg *ExpressionGenerator) GenerateIntMultiplication(leftInt int64, rightInt
 	leftReg := rp.GetTmpRegister()
 	rightReg := rp.GetTmpRegister()
 
-	cg.emit("li %s, %d", leftReg, leftInt)
-	cg.emit("li %s, %d", rightReg, rightInt)
-	cg.emit("mul a0, %s, %s", leftReg, rightReg)
+	cg.emit("	li %s, %d", leftReg, leftInt)
+	cg.emit("	li %s, %d", rightReg, rightInt)
+	cg.emit("	mul a0, %s, %s", leftReg, rightReg)
 	// The result will be a 128 bit integer, but for now we will just return the lower 64 bits
 	// Meaning we will ignore overflow, very C-like
 
@@ -447,17 +449,19 @@ func (eg *ExpressionGenerator) GenerateFloatMultiplication(leftFloat float64, ri
 	cg.insertData("double_1", ".double", leftFloat)
 	cg.insertData("double_2", ".double", rightFloat)
 
+	leftAddressReg := rp.GetTmpRegister()
+	rightAddressReg := rp.GetTmpRegister()
 	// Load float values into registers
 	leftReg := rp.GetFloatTmpRegister()
 	rightReg := rp.GetFloatTmpRegister()
 	// Load left float value
-	cg.emit("la %s, double_1", leftReg)
-	cg.emit("fld %s, 0(%s)", leftReg, leftReg)
+	cg.emit("	la %s, double_1", leftAddressReg)
+	cg.emit("	fld %s, 0(%s)", leftReg, leftAddressReg)
 	// Load right float value
-	cg.emit("la %s, double_2", rightReg)
-	cg.emit("fld %s, 0(%s)", rightReg, rightReg)
+	cg.emit("	la %s, double_2", rightAddressReg)
+	cg.emit("	fld %s, 0(%s)", rightReg, rightAddressReg)
 	// Perform subtraction
-	cg.emit("fmul.d fa0, %s, %s", leftReg, rightReg)
+	cg.emit("	fmul.d fa0, %s, %s", leftReg, rightReg)
 
 	return "fa0"
 }
@@ -505,9 +509,9 @@ func (eg *ExpressionGenerator) GenerateIntSubtraction(leftInt int64, rightInt in
 	leftReg := rp.GetTmpRegister()
 	rightReg := rp.GetTmpRegister()
 
-	cg.emit("li %s, %d", leftReg, leftInt)
-	cg.emit("li %s, %d", rightReg, rightInt)
-	cg.emit("sub a0, %s, %s", leftReg, rightReg)
+	cg.emit("	li %s, %d", leftReg, leftInt)
+	cg.emit("	li %s, %d", rightReg, rightInt)
+	cg.emit("	sub a0, %s, %s", leftReg, rightReg)
 
 	return "a0"
 }
@@ -519,17 +523,19 @@ func (eg *ExpressionGenerator) GenerateFloatSubtraction(leftFloat float64, right
 	cg.insertData("double_1", ".double", leftFloat)
 	cg.insertData("double_2", ".double", rightFloat)
 
+	leftAddressReg := rp.GetTmpRegister()
+	rightAddressReg := rp.GetTmpRegister()
 	// Load float values into registers
 	leftReg := rp.GetFloatTmpRegister()
 	rightReg := rp.GetFloatTmpRegister()
 	// Load left float value
-	cg.emit("la %s, double_1", leftReg)
-	cg.emit("fld %s, 0(%s)", leftReg, leftReg)
+	cg.emit("	la %s, double_1", leftAddressReg)
+	cg.emit("	fld %s, 0(%s)", leftReg, leftAddressReg)
 	// Load right float value
-	cg.emit("la %s, double_2", rightReg)
-	cg.emit("fld %s, 0(%s)", rightReg, rightReg)
+	cg.emit("	la %s, double_2", rightAddressReg)
+	cg.emit("	fld %s, 0(%s)", rightReg, rightAddressReg)
 	// Perform subtraction
-	cg.emit("fsub.d fa0, %s, %s", leftReg, rightReg)
+	cg.emit("	fsub.d fa0, %s, %s", leftReg, rightReg)
 
 	return "fa0"
 
@@ -589,15 +595,15 @@ func (eg *ExpressionGenerator) GenerateIntAddition(leftInt int64, rightInt int64
 		if isImmediateInt(rightInt) {
 			// Both are immediate integers
 			reg := rp.GetTmpRegister()
-			cg.emit("li %s, %d", reg, leftInt)
-			cg.emit("addi a0, %s, %d", reg, rightInt)
+			cg.emit("	li %s, %d", reg, leftInt)
+			cg.emit("	addi a0, %s, %d", reg, rightInt)
 			// return reg
 		} else {
 			// Left is immediate, right is not
 			// Load right operand into a register
 			rightReg := rp.GetTmpRegister()
-			cg.emit("li %s, %d", rightReg, rightInt)
-			cg.emit("addi a0, %s, %d", rightReg, leftInt)
+			cg.emit("	li %s, %d", rightReg, rightInt)
+			cg.emit("	addi a0, %s, %d", rightReg, leftInt)
 			// return rightReg
 		}
 
@@ -606,17 +612,17 @@ func (eg *ExpressionGenerator) GenerateIntAddition(leftInt int64, rightInt int64
 			// Left is not immediate, right is
 			// Load left operand into a register
 			leftReg := rp.GetTmpRegister()
-			cg.emit("li %s, %d", leftReg, leftInt)
-			cg.emit("addi a0, %s, %d", leftReg, rightInt)
+			cg.emit("	li %s, %d", leftReg, leftInt)
+			cg.emit("	addi a0, %s, %d", leftReg, rightInt)
 			// return leftReg
 		} else {
 			// Both are not immediate integers
 			// Load both operands into registers
 			leftReg := rp.GetTmpRegister()
 			rightReg := rp.GetTmpRegister()
-			cg.emit("li %s, %d", leftReg, leftInt)
-			cg.emit("li %s, %d", rightReg, rightInt)
-			cg.emit("add a0, %s, %s", leftReg, rightReg)
+			cg.emit("	li %s, %d", leftReg, leftInt)
+			cg.emit("	li %s, %d", rightReg, rightInt)
+			cg.emit("	add a0, %s, %s", leftReg, rightReg)
 			// return leftReg
 		}
 	}
@@ -632,17 +638,19 @@ func (eg *ExpressionGenerator) GenerateFloatAddition(leftFloat float64, rightFlo
 	cg.insertData("double_1", ".double", leftFloat)
 	cg.insertData("double_2", ".double", rightFloat)
 
+	leftAddressReg := rp.GetTmpRegister()
+	rightAddressReg := rp.GetTmpRegister()
 	// Load float values into registers
 	leftReg := rp.GetFloatTmpRegister()
 	rightReg := rp.GetFloatTmpRegister()
 	// Load left float value
-	cg.emit("la %s, double_1", leftReg)
-	cg.emit("fld %s, 0(%s)", leftReg, leftReg)
+	cg.emit("	la %s, double_1", leftAddressReg)
+	cg.emit("	fld %s, 0(%s)", leftReg, leftAddressReg)
 	// Load right float value
-	cg.emit("la %s, double_2", rightReg)
-	cg.emit("fld %s, 0(%s)", rightReg, rightReg)
+	cg.emit("	la %s, double_2", rightAddressReg)
+	cg.emit("	fld %s, 0(%s)", rightReg, rightAddressReg)
 	// Perform addition
-	cg.emit("fadd.d fa0, %s, %s", leftReg, rightReg)
+	cg.emit("	fadd.d fa0, %s, %s", leftReg, rightReg)
 	// Should the result be stored inside a register or in the data section?
 	// If the result is assigned to a variable, it should be stored in the data section
 	// Else, it should be stored in a register

--- a/pkg/codegen/function_gen.go
+++ b/pkg/codegen/function_gen.go
@@ -6,7 +6,7 @@ import (
 )
 
 type FunctionGenerator struct {
-    CodeGen     *CodeGenerator
+	CodeGen *CodeGenerator
 }
 
 func NewFunctionGenerator(cg *CodeGenerator) *FunctionGenerator {
@@ -26,46 +26,46 @@ func (fg *FunctionGenerator) calculateFrameSize(funcName string) int {
 
 	n_param := len(funcSymbol.Parameters)
 	if n_param > 8 {
-		// we have 8 registers a0-a7 to store up to 8 params 
+		// we have 8 registers a0-a7 to store up to 8 params
 		// but if we need more, we need to allocate additional stack space
 		// the stack is in memory (not cpu like registers)
-		// --> only allocate additional stack space if needed 
+		// --> only allocate additional stack space if needed
 		fs += (n_param - 8) * 8
 	}
 
 	funcScope := funcSymbol.Scope
 	for _, symbol := range table.Symbols {
-		if 	symbol.Scope.ValidFirstLine >= funcScope.ValidFirstLine && 
+		if symbol.Scope.ValidFirstLine >= funcScope.ValidFirstLine &&
 			symbol.Scope.ValidLastLine <= funcScope.ValidLastLine &&
 			symbol.Name != funcName {
-				// we counted this before so skip this symbol
-				isParam := false 
-				for _, param := range funcSymbol.Parameters {
-					if param.Name == symbol.Name {
-						isParam = true
-						break
-					}
+			// we counted this before so skip this symbol
+			isParam := false
+			for _, param := range funcSymbol.Parameters {
+				if param.Name == symbol.Name {
+					isParam = true
+					break
+				}
+			}
+
+			if !isParam {
+				var size int
+
+				if symbol.ArraySize > 0 {
+					elemSize := 8
+					size = int(symbol.ArraySize) * elemSize
+				} else {
+					// if not an array then its just 8
+					size = 8
 				}
 
-				if !isParam {
-					var size int 
-
-					if symbol.ArraySize > 0 {
-						elemSize := 8 
-						size = int(symbol.ArraySize) * elemSize
-					} else {
-						// if not an array then its just 8
-						size = 8
-					}
-
-					fs += size
-				}
+				fs += size
+			}
 		}
 	}
 
-	// in case the framesize is not multiple of 16 --> round it up to nearest 
+	// in case the framesize is not multiple of 16 --> round it up to nearest
 	// see this: https://riscv.org/wp-content/uploads/2024/12/riscv-calling.pdf
-	// tl;dr: "In the standard RISC-V calling convention, the stack grows downward 
+	// tl;dr: "In the standard RISC-V calling convention, the stack grows downward
 	// and the stack pointer is always kept 16-byte aligned."
 	rem := fs % 16
 	if rem != 0 {
@@ -76,60 +76,60 @@ func (fg *FunctionGenerator) calculateFrameSize(funcName string) int {
 }
 
 func typeString(astType ast.Type) string {
-    if p, ok := astType.(*ast.PrimitiveType); ok {
-        return p.Name
-    }
-    if a, ok := astType.(*ast.ArrayType); ok {
-        size := -1
-        if lit, ok := a.Size.(*ast.IntegerLiteral); ok {
-            size = int(lit.Value)
-        }
-        return fmt.Sprintf("%s[%d]", typeString(a.ElementType), size)
-    }
-    return "unknown"
+	if p, ok := astType.(*ast.PrimitiveType); ok {
+		return p.Name
+	}
+	if a, ok := astType.(*ast.ArrayType); ok {
+		size := -1
+		if lit, ok := a.Size.(*ast.IntegerLiteral); ok {
+			size = int(lit.Value)
+		}
+		return fmt.Sprintf("%s[%d]", typeString(a.ElementType), size)
+	}
+	return "unknown"
 }
 
 func (fg *FunctionGenerator) GenerateFunctionDeclaration(funcDecl ast.FunctionDeclaration) {
 	/*
-	Convention: 
-	- registers have roles as described in CodeGenerator struct 
-	- stack frame size: framesize represents the total size of function's stack frame. 
-	because we are in riscv 64-bit mode:
-		- 8 bytes per saved registers
-		- 8 bytes per local variables 
-		- --> total should be a multiple of 16 bytes for proper alignment
+		Convention:
+		- registers have roles as described in CodeGenerator struct
+		- stack frame size: framesize represents the total size of function's stack frame.
+		because we are in riscv 64-bit mode:
+			- 8 bytes per saved registers
+			- 8 bytes per local variables
+			- --> total should be a multiple of 16 bytes for proper alignment
 
-	Prologue: 
-	- allocate stack space for local var 
-	- saved calle-save registers (agreement between functions: callee-saved registers s0-s11 must 
-	have the same values when a function returns as when it was called. we backup the values in
-	these registers so that we can use it and restore values before returning)
-	- set value of frame pointer s0/fp to access local var (stable, reliable reference point to access 
-	local var and params)
+		Prologue:
+		- allocate stack space for local var
+		- saved calle-save registers (agreement between functions: callee-saved registers s0-s11 must
+		have the same values when a function returns as when it was called. we backup the values in
+		these registers so that we can use it and restore values before returning)
+		- set value of frame pointer s0/fp to access local var (stable, reliable reference point to access
+		local var and params)
 
-	Epilogue: 
-	- restore saved register in reverse order (to the values we backup in prologue)
-	- restore frame pointer (because s0/fp itself is a callee-saved register)
-	- deallocate stack frame 
-	- returns to the caller (`ret` instruction returns to address stored in `ra` register)
+		Epilogue:
+		- restore saved register in reverse order (to the values we backup in prologue)
+		- restore frame pointer (because s0/fp itself is a callee-saved register)
+		- deallocate stack frame
+		- returns to the caller (`ret` instruction returns to address stored in `ra` register)
 	*/
 	cg := fg.CodeGen
 	cg.CurrentFunction = funcDecl.Name
 	funcName := funcDecl.Name
 	fs := fg.calculateFrameSize(funcName)
-	
+
 	// function label
 	cg.emit("%s:", funcName)
 
-	// function prologue 
+	// function prologue
 	cg.emitComment("function prologue")
-	cg.emit("	addi sp, sp, -%d", 	fs)		// allocate stack space
-	cg.emit("	sd ra, %d(sp)", 	fs-8)	// save return address (ra)
-	cg.emit("	sd s0, %d(sp)", 	fs-16)  // save frame pointer
-	cg.emit("	addi s0, sp, %d", 	fs)		// set frame pointer to this function's scope
+	cg.emit("	addi sp, sp, -%d", fs) // allocate stack space
+	cg.emit("	sd ra, %d(sp)", fs-8)  // save return address (ra)
+	cg.emit("	sd s0, %d(sp)", fs-16) // save frame pointer
+	cg.emit("	addi s0, sp, %d", fs)  // set frame pointer to this function's scope
 
 	// function parameters & local var
-	cg.emitComment("setup parameters") 
+	cg.emitComment("setup parameters")
 	funcSymbol, _ := cg.SymTable.Lookup(funcName)
 	params := funcSymbol.Parameters
 
@@ -140,48 +140,48 @@ func (fg *FunctionGenerator) GenerateFunctionDeclaration(funcDecl ast.FunctionDe
 			cg.emitComment("param %s in register a%d", param.Name, i)
 		} else { // needs stack
 			// first memory is to backup ra
-			// second memory is to backup s0 
-			offset := 16 + 8*(i-8) 
+			// second memory is to backup s0
+			offset := 16 + 8*(i-8)
 			cg.VarStackOffset[param.Name] = offset
 			cg.emitComment("param %s at offset %d(sp)", param.Name, offset)
 		}
 	}
 
-	localVarOffset := 16 
+	localVarOffset := 16
 	if len(params) > 8 {
-		localVarOffset += (len(params)-8)*8
+		localVarOffset += (len(params) - 8) * 8
 	}
 
-	funcScope := funcSymbol.Scope 
+	funcScope := funcSymbol.Scope
 	for _, symbol := range cg.SymTable.Symbols {
-		if 	(symbol.Name != funcName) &&
+		if (symbol.Name != funcName) &&
 			(typeString(symbol.Type) != "function") &&
 			(symbol.Scope.ValidFirstLine >= funcScope.ValidFirstLine) &&
 			(symbol.Scope.ValidLastLine <= funcScope.ValidLastLine) {
-				isParam := false
-				for _, param := range params {
-					if param.Name == symbol.Name {
-						isParam = true 
-						break
-					}
-				}
-
-				if !isParam {
-					var size int 
-					if /*symbol.ArraySize != nil &&*/ symbol.ArraySize > 0 {
-						size = int(symbol.ArraySize)*8
-					} else {
-						size = 8
-					}
-
-					cg.VarStackOffset[symbol.Name] = localVarOffset
-					cg.emitComment("local var %s at offset %d(sp)", symbol.Name, localVarOffset)
-					localVarOffset += size
+			isParam := false
+			for _, param := range params {
+				if param.Name == symbol.Name {
+					isParam = true
+					break
 				}
 			}
+
+			if !isParam {
+				var size int
+				if /*symbol.ArraySize != nil &&*/ symbol.ArraySize > 0 {
+					size = int(symbol.ArraySize) * 8
+				} else {
+					size = 8
+				}
+
+				cg.VarStackOffset[symbol.Name] = localVarOffset
+				cg.emitComment("local var %s at offset %d(sp)", symbol.Name, localVarOffset)
+				localVarOffset += size
+			}
+		}
 	}
 
-	// function body 
+	// function body
 	cg.emitComment("function body")
 	if funcDecl.Body != nil {
 		for _, stmt := range funcDecl.Body.Items {
@@ -190,10 +190,10 @@ func (fg *FunctionGenerator) GenerateFunctionDeclaration(funcDecl ast.FunctionDe
 	}
 
 	// function epilogue
-	cg.emitComment("function epilogue") 
-	cg.emit("	ld ra, %d(sp)", fs-8)	// restore ra (of caller func)
-	cg.emit("	ld s0, %d(sp)", fs-16)	// restore fp
-	cg.emit("	addi sp, sp, %d", fs) 	// deallocate stack frame pointer				
+	cg.emitComment("function epilogue")
+	cg.emit("	ld ra, %d(sp)", fs-8)  // restore ra (of caller func)
+	cg.emit("	ld s0, %d(sp)", fs-16) // restore fp
+	cg.emit("	addi sp, sp, %d", fs)  // deallocate stack frame pointer
 
 	if funcName == "main" {
 		cg.emit("	j _exit") // Special case for main
@@ -218,10 +218,10 @@ func (fg *FunctionGenerator) GenerateReturnStatement(stmt ast.ReturnStatement) {
 		}
 
 		if returnType == "float" && resultRegister != "fa0" {
-            fg.CodeGen.emit("    fmv.d fa0, %s", resultRegister)
-        } else if returnType != "float" && resultRegister != "a0" {
-            fg.CodeGen.emit("    mv a0, %s", resultRegister)
-        }
+			fg.CodeGen.emit("	fmv.d fa0, %s", resultRegister)
+		} else if returnType != "float" && resultRegister != "a0" {
+			fg.CodeGen.emit("	mv a0, %s", resultRegister)
+		}
 
 		if resultRegister != "a0" && resultRegister != "fa0" {
 			fg.CodeGen.Registers.ReleaseRegister(resultRegister)
@@ -229,40 +229,40 @@ func (fg *FunctionGenerator) GenerateReturnStatement(stmt ast.ReturnStatement) {
 	}
 }
 
-func (fg *FunctionGenerator) getFunctionReturnType (funcName string) string {
+func (fg *FunctionGenerator) getFunctionReturnType(funcName string) string {
 	if symbol, found := fg.CodeGen.SymTable.Lookup(funcName); found {
-        if symbol.ReturnType != nil {
-            if primitiveType, ok := symbol.ReturnType.(*ast.PrimitiveType); ok {
-                return primitiveType.Name
-            }
-        }
-    }
-    return ""
+		if symbol.ReturnType != nil {
+			if primitiveType, ok := symbol.ReturnType.(*ast.PrimitiveType); ok {
+				return primitiveType.Name
+			}
+		}
+	}
+	return ""
 }
 
 func (fg *FunctionGenerator) GenerateBlockItem(stmt ast.BlockItem) {
 	cg := fg.CodeGen
 	switch s := stmt.(type) {
-	case *ast.ExpressionStatement: 
+	case *ast.ExpressionStatement:
 		cg.ExpressionGen.GenerateExpression(s.Expr)
 	case *ast.ReturnStatement:
 		fg.GenerateReturnStatement(*s)
 	case *ast.IfStatement:
 		cg.BranchingGen.GenerateIfStatement(*s)
-	case *ast.WhileStatement: 
+	case *ast.WhileStatement:
 		cg.LoopingGen.GenerateWhileStatement(*s)
 	case *ast.VarDeclaration:
-		// it makes sense why this func does not take 
+		// it makes sense why this func does not take
 		// argument but be careful this may cause problem
 		cg.AssignmentGen.GenerateVarDeclaration(*s) // watch out
 	// case *ast.Block:
-    //     fg.GenerateBlock(*s)
+	//     fg.GenerateBlock(*s)
 	case *ast.FunctionDeclaration:
 		panic("nested function declaration not allowed")
-	default: 
+	default:
 		panic(fmt.Sprintf("unknown statement type in function body: %T", stmt))
 	}
-} 
+}
 
 // func (fg *FunctionGenerator) GenerateBlock(block ast.Block) {
 //     for _, item := range block.Items {


### PR DESCRIPTION
My dumbass forgot to load the address into an int register, and decided to load directly into a float register.
```asm
la ft0, double_1 # dumbass
fld ft0, 0(ft0)
```
It should be 
```asm
la t0, double_1 # smort
fld ft0, 0(t0)
```