### PR TITLE
Fix #60

### DIFF
--- a/pkg/codegen/assignment_gen.go
+++ b/pkg/codegen/assignment_gen.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"BigCooker/pkg/syntax/ast"
 	"fmt"
+	"math"
 )
 
 type AssignmentGenerator struct {
@@ -27,7 +28,7 @@ func (ag *AssignmentGenerator) GenerateVarDeclaration(varDecl *ast.VarDeclaratio
 	}
 
 	// Check if local (inside main) or global
-	isLocal := symbol.Scope.ValidFirstLine > 1 // Locals declared inside main
+	isLocal := symbol.Scope.ValidLastLine != math.MaxInt // Locals declared inside main
 	isFloat := isFloatType(varDecl.Type)
 	size := 8 // 8 bytes for int, float, bool, char
 	var offset int
@@ -142,7 +143,7 @@ func (ag *AssignmentGenerator) GenerateVariableAssignment(id *ast.Identifier, va
 	}
 
 	// Determine if local or global
-	isLocal := symbol.Scope.ValidFirstLine > 1 // Locals declared inside main
+	isLocal := symbol.Scope.ValidLastLine != math.MaxInt // Locals declared inside main
 	isFloat := isFloatType(symbol.Type)
 
 	if isLocal {

--- a/pkg/codegen/expression_gen.go
+++ b/pkg/codegen/expression_gen.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"BigCooker/pkg/syntax/ast"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -53,7 +54,7 @@ func (eg *ExpressionGenerator) GenerateIdentifier(expr *ast.Identifier) (string,
 	}
 
 	isFloatVar := isFloatType(symbol.Type)
-	isLocal := symbol.Scope.ValidFirstLine > 1 // Locals declared inside main
+	isLocal := symbol.Scope.ValidLastLine != math.MaxInt // Locals declared inside main
 
 	if isLocal {
 		// Load from stack
@@ -241,7 +242,7 @@ func (eg *ExpressionGenerator) CalculateArrayElementAddress(arrExpr ast.Expressi
 	}
 
 	// Determine if local or global
-	isLocal := symbol.Scope.ValidFirstLine > 1 // Locals declared inside main
+	isLocal := symbol.Scope.ValidLastLine != math.MaxInt // Locals declared inside main
 	baseAddrRegister := rp.GetTmpRegister()
 
 	if isLocal {


### PR DESCRIPTION
- I was recognizing global var with this logic
```go
isLocal := symbol.Scope.ValidFirstLine > 1 
```
But the start line is the line of declaration, so it only recognizes the first global var. Instead, use the end line, which is universal for all global variables
```go
isLocal := symbol.Scope.ValidLastLine != math.MaxInt
```
Works like a charm